### PR TITLE
Add end-to-end regression coverage for all JsonFile flag types (#37)

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -91,411 +91,250 @@ jobs:
           TestJsonConfigInstaller\bin\**\${{env.BUILD_CONFIGURATION}}\**\*.msi
         if-no-files-found: error
 
-    - name: Test JSON Validation
+    # ---------------------------------------------------------------------------
+    # End-to-end flag-type regression coverage.
+    #
+    # These steps install the real test MSI and assert the *extension's* behaviour
+    # by inspecting the JSON files it writes (and the install log). Every JsonFile
+    # action/flag is exercised, with both happy and sad paths:
+    #
+    #   readValue              - happy + missing element -> DefaultValue
+    #   setValue               - filtered, nested, multi-select, + OnlyIfExists
+    #   replaceJsonValue       - replace whole array from a property
+    #   createJsonPointerValue - create new paths / build a file from {}
+    #   deleteValue            - wildcard delete
+    #   appendArray            - append element
+    #   insertArray            - insert at index 0
+    #   removeArrayElement     - JSONPath filter delete
+    #   distinctValues         - de-duplicate arrays
+    #   validateSchema         - happy (passes) + sad (install fails)
+    #   OnlyIfExists           - update existing + skip missing
+    #   invalid JSON           - sad path (install fails)
+    # ---------------------------------------------------------------------------
+
+    - name: Prepare readValue source file
       shell: pwsh
       run: |
-        Write-Host "Testing JSON file validation..."
-
-        # Test 1: Valid JSON file
-        $validJson = @"
+        # readValue (WixPropertyJsonFile) runs after CostFinalize, i.e. BEFORE InstallFiles, so it
+        # cannot read a file installed in the same transaction. The test installer therefore reads
+        # this pre-existing file from a fixed location.
+        $dir = "C:\JsonRegression"
+        New-Item -ItemType Directory -Force -Path $dir | Out-Null
+        $source = @"
         {
-          "ConnectionStrings": {
-            "DefaultConnection": "Server=localhost;Database=Test;"
-          },
-          "Logging": {
-            "LogLevel": {
-              "Default": "Information"
-            }
+          "config": {
+            "environment": "Staging"
           }
         }
         "@
+        $source | Out-File -FilePath (Join-Path $dir "read-source.json") -Encoding UTF8
+        Write-Host "✓ Created C:\JsonRegression\read-source.json"
 
-        $testFile = "test-valid.json"
-        $validJson | Out-File -FilePath $testFile -Encoding UTF8
-
-        try {
-          $null = Get-Content $testFile | ConvertFrom-Json
-          Write-Host "✓ Valid JSON test passed"
-        } catch {
-          Write-Error "✗ Valid JSON test failed: $_"
-          exit 1
-        }
-
-        # Test 2: Invalid JSON file
-        $invalidJson = '{ "key": "value" '
-        $invalidFile = "test-invalid.json"
-        $invalidJson | Out-File -FilePath $invalidFile -Encoding UTF8
-
-        try {
-          $null = Get-Content $invalidFile | ConvertFrom-Json
-          Write-Error "✗ Invalid JSON test failed: Should have thrown an error"
-          exit 1
-        } catch {
-          Write-Host "✓ Invalid JSON test passed: Error caught as expected"
-        }
-
-        # Test 3: Verify test JSON files exist
-        $testJsonFiles = @(
-          "TestJsonConfigInstaller\appsettings.json",
-          "TestJsonConfigInstaller\appsettings.dotnet.json"
-        )
-
-        foreach ($file in $testJsonFiles) {
-          if (Test-Path $file) {
-            Write-Host "✓ Found: $file"
-            try {
-              $null = Get-Content $file | ConvertFrom-Json
-              Write-Host "  - Valid JSON structure"
-            } catch {
-              Write-Error "  - Invalid JSON structure: $_"
-              exit 1
-            }
-          } else {
-            Write-Error "✗ Missing: $file"
-            exit 1
-          }
-        }
-
-    - name: Test Non-ASCII JSON Values
+    - name: Install test MSI (happy path)
       shell: pwsh
       run: |
-        Write-Host "Testing non-ASCII JSON value handling through MSI installation..."
+        $msi = (Get-ChildItem -Path "TestJsonConfigInstaller\bin" -Filter "*.msi" -Recurse | Select-Object -First 1).FullName
+        if (-not $msi) { Write-Host "✗ Test installer MSI not found"; exit 1 }
+        Write-Host "Installing: $msi"
+
+        $log = Join-Path $env:RUNNER_TEMP "happy-install.log"
+
+        # MY_VALUE uses Cyrillic text to also regression-test non-ASCII (UTF-8) value handling.
+        # Passing it as its own Start-Process argument keeps it Unicode-safe.
+        $expectedCategory = "КатегорияПривет"
+        $argline = "/i `"$msi`" /qn /norestart /l*v `"$log`" MY_VALUE=$expectedCategory LOG_DIRECTORY=C:\temp\"
+        $p = Start-Process -FilePath "msiexec.exe" -ArgumentList $argline -Wait -PassThru
+        Write-Host "msiexec exit code: $($p.ExitCode)"
+
+        if ($p.ExitCode -ne 0 -and $p.ExitCode -ne 3010) {
+          Write-Host "✗ Happy-path install failed"
+          if (Test-Path $log) { Write-Host "----- msiexec log -----"; Get-Content -Path $log }
+          exit 1
+        }
+        Write-Host "✓ Happy-path install succeeded"
+
+    - name: Verify all flag types in installed JSON (happy paths)
+      shell: pwsh
+      run: |
+        $failed = $false
+        function Check([bool]$cond, [string]$msg) {
+          if ($cond) { Write-Host "  [PASS] $msg" } else { Write-Host "  [FAIL] $msg"; $script:failed = $true }
+        }
 
         $expectedCategory = "КатегорияПривет"
+        $installDir = Join-Path $env:ProgramFiles "TestJsonConfigInstaller"
 
-        # Find the built test MSI
-        $msiFiles = Get-ChildItem -Path "TestJsonConfigInstaller\bin" -Filter "*.msi" -Recurse
-        if ($msiFiles.Count -eq 0) {
-          Write-Error "✗ Test installer MSI not found"
+        $appPath = Join-Path $installDir "appsettings.json"
+        $cfgPath = Join-Path $installDir "config.json"
+        $setPath = Join-Path $installDir "settings.json"
+
+        foreach ($f in @($appPath, $cfgPath, $setPath)) {
+          if (-not (Test-Path $f)) { Write-Host "✗ Expected installed file missing: $f"; exit 1 }
+        }
+
+        $j = Get-Content -Path $appPath -Raw -Encoding UTF8 | ConvertFrom-Json
+
+        Write-Host "replaceJsonValue / setValue (filter) / non-ASCII:"
+        $books = @($j.store.book)
+        $moby = $books | Where-Object { $_.isbn -eq '0-553-21311-3' } | Select-Object -First 1
+        Check ($null -ne $moby) "book with isbn 0-553-21311-3 exists after replaceJsonValue"
+        Check ($moby.author -eq 'HermanMelville') "replaceJsonValue replaced array contents from MY_BOOKS"
+        Check ($moby.category -eq $expectedCategory) "setValue (JSONPath filter) wrote non-ASCII value to category"
+
+        Write-Host "appendArray / insertArray / removeArrayElement:"
+        Check ($books.Count -eq 3) "net array size is 3 (append + insert at 0 - remove price>20)"
+        Check ($books[0].title -eq 'Steve Jobs') "insertArray placed 'Steve Jobs' at index 0"
+        Check ((@($books | Where-Object { $_.title -eq 'Cosmos' })).Count -eq 1) "appendArray added 'Cosmos'"
+        Check ((@($books | Where-Object { $_.author -eq 'NigelRees' })).Count -eq 0) "removeArrayElement removed books priced > 20"
+
+        Write-Host "setValue (multi-select recursive descent):"
+        $prices = @($books.price) + @($j.store.bicycle.price)
+        $offPrice = @($prices | Where-Object { [math]::Abs([double]$_ - 9.99) -gt 0.001 })
+        Check ($offPrice.Count -eq 0) "`$..price multi-select set every price to 9.99"
+
+        Write-Host "deleteValue (wildcard):"
+        $withOldPrice = @($books | Where-Object { $_.PSObject.Properties.Name -contains 'OldPrice' })
+        Check ($withOldPrice.Count -eq 0) "deleteValue removed OldPrice from all books"
+
+        Write-Host "createJsonPointerValue:"
+        Check ($j.NonExisting -eq 'Value Not Set') "createJsonPointerValue created top-level /NonExisting"
+
+        Write-Host "setValue (deeply nested) using LOG_DIRECTORY property:"
+        $logPath = $j.Serilog.WriteTo[0].Args.configure[0].Args.path
+        Check ($logPath -like 'C:\temp\*') "nested setValue substituted [LOG_DIRECTORY]"
+        Check ($logPath -like '*PowerCommunications*') "nested setValue preserved path suffix"
+
+        Write-Host "OnlyIfExists:"
+        Check ($j.expensive -eq 15) "OnlyIfExists=yes updated existing 'expensive' to 15"
+        Check (-not ($j.PSObject.Properties.Name -contains 'nonExistentPath')) "OnlyIfExists=yes skipped missing 'nonExistentPath'"
+
+        Write-Host "distinctValues:"
+        $tags = @($j.tags)
+        Check ($tags.Count -eq 4) "distinctValues de-duplicated tags (6 -> 4)"
+        Check ((@($tags | Select-Object -Unique)).Count -eq $tags.Count) "tags contain no duplicates"
+        $feat = @($j.features.enabled)
+        Check ($feat.Count -eq 3) "distinctValues de-duplicated features.enabled (4 -> 3)"
+
+        Write-Host "setValue on a template file:"
+        $cfg = Get-Content -Path $cfgPath -Raw -Encoding UTF8 | ConvertFrom-Json
+        Check ($cfg.Application.Name -eq 'MyInstalledApp') "setValue updated Application.Name in template config"
+
+        Write-Host "createJsonPointerValue building a file from '{}':"
+        $set = Get-Content -Path $setPath -Raw -Encoding UTF8 | ConvertFrom-Json
+        Check ($set.Application.Name -eq 'MyApplication') "built Application.Name from empty file"
+        Check ($set.Application.Version -eq '2.0.0') "built Application.Version from empty file"
+        Check ($set.Logging.Level -eq 'Debug') "built Logging.Level from empty file"
+
+        if ($script:failed) { Write-Host "`nOne or more flag-type assertions FAILED"; exit 1 }
+        Write-Host "`n✓ All installed-JSON flag-type assertions passed"
+
+    - name: Verify readValue and validateSchema (from install log)
+      shell: pwsh
+      run: |
+        $failed = $false
+        function Check([bool]$cond, [string]$msg) {
+          if ($cond) { Write-Host "  [PASS] $msg" } else { Write-Host "  [FAIL] $msg"; $script:failed = $true }
+        }
+
+        $log = Join-Path $env:RUNNER_TEMP "happy-install.log"
+        if (-not (Test-Path $log)) { Write-Host "✗ Install log not found: $log"; exit 1 }
+        $content = Get-Content -Path $log -Raw
+
+        Write-Host "readValue:"
+        Check ($content -match "REG_READ_PRESENT.*Staging") "readValue read existing value ('Staging') into a property"
+        Check ($content -match "REG_READ_MISSING.*READ_DEFAULT") "readValue applied DefaultValue for a missing element"
+
+        Write-Host "validateSchema (happy):"
+        Check ($content -match "JSON schema validation successful") "SchemaFile validation passed for the valid file"
+
+        if ($script:failed) { Write-Host "`nreadValue/validateSchema log assertions FAILED"; exit 1 }
+        Write-Host "`n✓ readValue and validateSchema (happy) assertions passed"
+
+    - name: Uninstall happy-path product
+      shell: pwsh
+      run: |
+        $log = Join-Path $env:RUNNER_TEMP "uninstall.log"
+        $p = Start-Process -FilePath "msiexec.exe" -ArgumentList "/x {C9A3F6AF-7F4F-473F-BFFC-6143EB1AA0D4} /qn /norestart /l*v `"$log`"" -Wait -PassThru
+        Write-Host "Uninstall exit code: $($p.ExitCode)"
+
+    - name: Sad path - invalid JSON aborts install
+      shell: pwsh
+      run: |
+        $msi = (Get-ChildItem -Path "TestJsonConfigInstaller\bin" -Filter "*.msi" -Recurse | Select-Object -First 1).FullName
+        $log = Join-Path $env:RUNNER_TEMP "invalid-json.log"
+
+        # TEST_INVALID_JSON=1 enables a component that operates on malformed JSON; the custom action
+        # must fail, which aborts and rolls back the installation.
+        $p = Start-Process -FilePath "msiexec.exe" -ArgumentList "/i `"$msi`" /qn /norestart /l*v `"$log`" TEST_INVALID_JSON=1" -Wait -PassThru
+        Write-Host "msiexec exit code: $($p.ExitCode)"
+
+        if ($p.ExitCode -eq 0 -or $p.ExitCode -eq 3010) {
+          Write-Host "✗ Install unexpectedly SUCCEEDED with invalid JSON (expected failure)"
+          # Best-effort cleanup so later steps start clean.
+          Start-Process -FilePath "msiexec.exe" -ArgumentList "/x {C9A3F6AF-7F4F-473F-BFFC-6143EB1AA0D4} /qn /norestart" -Wait | Out-Null
           exit 1
         }
-        $msiPath = $msiFiles[0].FullName
-        Write-Host "Using MSI: $msiPath"
+        Write-Host "✓ Invalid JSON correctly aborted the install (exit $($p.ExitCode))"
 
-        # Install the MSI with a Cyrillic installer property that is written by the JsonFile custom
-        # action. Only MY_VALUE is passed here (Unicode-safe via Start-Process); the remaining
-        # properties such as MY_BOOKS and LOG_DIRECTORY have defaults defined in Product.wxs.
-        $logPath = Join-Path $env:RUNNER_TEMP "nonascii-install.log"
-        $install = Start-Process -FilePath "msiexec.exe" -ArgumentList "/i `"$msiPath`" /qn /norestart /l*v `"$logPath`" MY_VALUE=$expectedCategory" -Wait -PassThru
-        if ($install.ExitCode -ne 0) {
-          # Use Write-Host (not Write-Error) so the log dump still runs: GitHub Actions sets
-          # $ErrorActionPreference='Stop', which would otherwise terminate the step immediately.
-          Write-Host "✗ MSI installation failed with exit code $($install.ExitCode)"
-          if (Test-Path $logPath) {
-            Write-Host "----- msiexec log -----"
-            Get-Content -Path $logPath
+        if (Test-Path $log) {
+          $content = Get-Content -Path $log -Raw
+          if ($content -match "invalid.json") {
+            Write-Host "✓ Install log references the invalid JSON file"
           } else {
-            Write-Host "(no msiexec log was produced at $logPath)"
+            Write-Host "  (note: invalid.json not referenced in log; relying on non-zero exit code)"
           }
-          exit 1
         }
 
-        # Verify the installed JSON file remains valid and contains the expected Cyrillic value
-        $installedJsonPath = Join-Path $env:ProgramFiles "TestJsonConfigInstaller\appsettings.json"
-        if (-not (Test-Path $installedJsonPath)) {
-          Write-Error "✗ Installed JSON file not found at $installedJsonPath"
-          exit 1
-        }
-
-        try {
-          $installedJson = Get-Content -Path $installedJsonPath -Raw -Encoding UTF8 | ConvertFrom-Json
-        } catch {
-          Write-Error "✗ Installed JSON file is not valid UTF-8 JSON: $_"
-          exit 1
-        }
-
-        $updatedBook = $installedJson.store.book | Where-Object { $_.isbn -eq "0-553-21311-3" } | Select-Object -First 1
-        if ($null -eq $updatedBook) {
-          Write-Error "✗ Could not find target book entry in installed JSON"
-          exit 1
-        }
-
-        if ($updatedBook.category -ne $expectedCategory) {
-          Write-Error "✗ Cyrillic value was not preserved correctly. Expected '$expectedCategory', got '$($updatedBook.category)'"
-          exit 1
-        }
-
-        Write-Host "✓ Non-ASCII JSON value tests passed"
-
-    - name: Test Common .NET Patterns
+    - name: Sad path - schema validation failure aborts install
       shell: pwsh
       run: |
-        Write-Host "Testing common .NET configuration patterns..."
+        $msi = (Get-ChildItem -Path "TestJsonConfigInstaller\bin" -Filter "*.msi" -Recurse | Select-Object -First 1).FullName
+        $log = Join-Path $env:RUNNER_TEMP "schema-failure.log"
 
-        # Create a test appsettings.json
-        $testConfig = @"
-        {
-          "ConnectionStrings": {
-            "DefaultConnection": "Server=localhost;Database=MyDb;"
-          },
-          "Logging": {
-            "LogLevel": {
-              "Default": "Information",
-              "Microsoft": "Warning"
-            }
-          },
-          "ApplicationSettings": {
-            "DataPath": "C:\\ProgramData\\MyApp\\Data"
+        # TEST_SCHEMA_FAILURE=1 enables a component whose JSON is valid but violates the schema
+        # (missing required "store"); schema validation must fail and abort the install.
+        $p = Start-Process -FilePath "msiexec.exe" -ArgumentList "/i `"$msi`" /qn /norestart /l*v `"$log`" TEST_SCHEMA_FAILURE=1" -Wait -PassThru
+        Write-Host "msiexec exit code: $($p.ExitCode)"
+
+        if ($p.ExitCode -eq 0 -or $p.ExitCode -eq 3010) {
+          Write-Host "✗ Install unexpectedly SUCCEEDED despite schema violation (expected failure)"
+          Start-Process -FilePath "msiexec.exe" -ArgumentList "/x {C9A3F6AF-7F4F-473F-BFFC-6143EB1AA0D4} /qn /norestart" -Wait | Out-Null
+          exit 1
+        }
+        Write-Host "✓ Schema violation correctly aborted the install (exit $($p.ExitCode))"
+
+        if (Test-Path $log) {
+          $content = Get-Content -Path $log -Raw
+          if ($content -match "Schema validation failed" -or $content -match "Required property missing") {
+            Write-Host "✓ Install log shows the schema validation failure"
+          } else {
+            Write-Host "  (note: schema failure message not found in log; relying on non-zero exit code)"
           }
         }
-        "@
 
-        $configFile = "test-config.json"
-        $testConfig | Out-File -FilePath $configFile -Encoding UTF8
-
-        # Parse and verify structure
-        $config = Get-Content $configFile | ConvertFrom-Json
-
-        # Test ConnectionStrings
-        if ($config.ConnectionStrings.DefaultConnection) {
-          Write-Host "✓ ConnectionStrings.DefaultConnection exists"
-        } else {
-          Write-Error "✗ ConnectionStrings.DefaultConnection not found"
-          exit 1
-        }
-
-        # Test Logging
-        if ($config.Logging.LogLevel.Default -eq "Information") {
-          Write-Host "✓ Logging.LogLevel.Default is correct"
-        } else {
-          Write-Error "✗ Logging.LogLevel.Default is incorrect"
-          exit 1
-        }
-
-        # Test Application Settings
-        if ($config.ApplicationSettings.DataPath) {
-          Write-Host "✓ ApplicationSettings.DataPath exists"
-        } else {
-          Write-Error "✗ ApplicationSettings.DataPath not found"
-          exit 1
-        }
-
-        Write-Host "All common .NET pattern tests passed!"
-
-    - name: Test JSONPath Patterns
+    - name: Verify repository test JSON fixtures
       shell: pwsh
       run: |
-        Write-Host "Testing JSONPath pattern scenarios..."
-
-        # Create test JSON with nested arrays
-        $complexJson = @"
-        {
-          "store": {
-            "book": [
-              {
-                "category": "reference",
-                "author": "Nigel Rees",
-                "title": "Sayings of the Century",
-                "price": 8.95
-              },
-              {
-                "category": "fiction",
-                "author": "Herman Melville",
-                "title": "Moby Dick",
-                "isbn": "0-553-21311-3",
-                "price": 8.99
-              }
-            ]
-          }
-        }
-        "@
-
-        $jsonFile = "test-jsonpath.json"
-        $complexJson | Out-File -FilePath $jsonFile -Encoding UTF8
-
-        $data = Get-Content $jsonFile | ConvertFrom-Json
-
-        # Test array access
-        if ($data.store.book[0].title -eq "Sayings of the Century") {
-          Write-Host "✓ Array access test passed"
-        } else {
-          Write-Error "✗ Array access test failed"
-          exit 1
+        $failed = $false
+        function Check([bool]$cond, [string]$msg) {
+          if ($cond) { Write-Host "  [PASS] $msg" } else { Write-Host "  [FAIL] $msg"; $script:failed = $true }
         }
 
-        # Test nested property access
-        if ($data.store.book[1].isbn -eq "0-553-21311-3") {
-          Write-Host "✓ Nested property access test passed"
-        } else {
-          Write-Error "✗ Nested property access test failed"
-          exit 1
+        # Valid fixtures should parse.
+        foreach ($f in @("TestJsonConfigInstaller\appsettings.json", "TestJsonConfigInstaller\appsettings.dotnet.json")) {
+          $ok = $true
+          try { $null = Get-Content $f -Raw | ConvertFrom-Json } catch { $ok = $false }
+          Check $ok "fixture parses as valid JSON: $f"
         }
 
-        Write-Host "All JSONPath pattern tests passed!"
-
-    - name: Test distinctValues Action
-      shell: pwsh
-      run: |
-        Write-Host "Testing distinctValues action..."
-
-        # Create test JSON with duplicate values in arrays
-        $jsonWithDuplicates = @"
-        {
-          "tags": ["production", "webapp", "production", "backend", "webapp", "api"],
-          "features": {
-            "enabled": ["feature1", "feature2", "feature1", "feature3"]
-          },
-          "settings": {
-            "values": [1, 2, 3, 2, 4, 1, 5]
-          }
-        }
-        "@
-
-        $testFile = "test-duplicates.json"
-        $jsonWithDuplicates | Out-File -FilePath $testFile -Encoding UTF8
-
-        # Verify the test file has duplicates
-        $data = Get-Content $testFile | ConvertFrom-Json
-
-        # Test 1: Verify tags array has duplicates
-        $uniqueTags = $data.tags | Select-Object -Unique
-        if ($uniqueTags.Count -lt $data.tags.Count) {
-          Write-Host "✓ Test data contains duplicate tags (expected)"
-        } else {
-          Write-Error "✗ Test data should contain duplicate tags"
-          exit 1
+        # Intentionally invalid fixtures should NOT parse.
+        foreach ($f in @("TestJsonConfigInstaller\invalid.json")) {
+          $ok = $false
+          try { $null = Get-Content $f -Raw | ConvertFrom-Json } catch { $ok = $true }
+          Check $ok "fixture is correctly malformed: $f"
         }
 
-        # Test 2: Verify features.enabled array has duplicates
-        $uniqueFeatures = $data.features.enabled | Select-Object -Unique
-        if ($uniqueFeatures.Count -lt $data.features.enabled.Count) {
-          Write-Host "✓ Test data contains duplicate features (expected)"
-        } else {
-          Write-Error "✗ Test data should contain duplicate features"
-          exit 1
-        }
-
-        # Test 3: Verify numeric array has duplicates
-        $uniqueValues = $data.settings.values | Select-Object -Unique
-        if ($uniqueValues.Count -lt $data.settings.values.Count) {
-          Write-Host "✓ Test data contains duplicate numeric values (expected)"
-        } else {
-          Write-Error "✗ Test data should contain duplicate numeric values"
-          exit 1
-        }
-
-        Write-Host "All distinctValues action tests passed!"
-
-    - name: Test OnlyIfExists Attribute
-      shell: pwsh
-      run: |
-        Write-Host "Testing OnlyIfExists attribute..."
-
-        # Create test JSON with some existing and some missing paths
-        $testJson = @"
-        {
-          "ConnectionStrings": {
-            "Database": "Server=localhost;Database=Test;"
-          },
-          "Logging": {
-            "LogLevel": {
-              "Default": "Information"
-            }
-          },
-          "AppSettings": {
-            "Version": "1.0.0"
-          }
-        }
-        "@
-
-        $testFile = "test-onlyifexists.json"
-        $testJson | Out-File -FilePath $testFile -Encoding UTF8
-
-        $data = Get-Content $testFile | ConvertFrom-Json
-
-        # Test 1: Verify existing path - ConnectionStrings.Database
-        if ($data.ConnectionStrings.Database) {
-          Write-Host "✓ ConnectionStrings.Database exists (should be updated with OnlyIfExists=yes)"
-        } else {
-          Write-Error "✗ ConnectionStrings.Database should exist"
-          exit 1
-        }
-
-        # Test 2: Verify existing path - Logging.LogLevel.Default
-        if ($data.Logging.LogLevel.Default) {
-          Write-Host "✓ Logging.LogLevel.Default exists (should be updated with OnlyIfExists=yes)"
-        } else {
-          Write-Error "✗ Logging.LogLevel.Default should exist"
-          exit 1
-        }
-
-        # Test 3: Verify non-existing path - NonExistentSection
-        if (-not $data.NonExistentSection) {
-          Write-Host "✓ NonExistentSection does not exist (should be skipped with OnlyIfExists=yes)"
-        } else {
-          Write-Error "✗ NonExistentSection should not exist"
-          exit 1
-        }
-
-        # Test 4: Verify non-existing nested path
-        if (-not $data.AppSettings.NonExistentProperty) {
-          Write-Host "✓ AppSettings.NonExistentProperty does not exist (should be skipped with OnlyIfExists=yes)"
-        } else {
-          Write-Error "✗ AppSettings.NonExistentProperty should not exist"
-          exit 1
-        }
-
-        Write-Host "All OnlyIfExists attribute tests passed!"
-
-    - name: Test Multi-Select and Filter Operations
-      shell: pwsh
-      run: |
-        Write-Host "Testing multi-select and filter operations..."
-
-        # Create test JSON with multiple matching elements
-        $multiSelectJson = @"
-        {
-          "products": [
-            {"name": "Product A", "price": 10.00, "category": "electronics"},
-            {"name": "Product B", "price": 25.00, "category": "electronics"},
-            {"name": "Product C", "price": 15.00, "category": "books"},
-            {"name": "Product D", "price": 30.00, "category": "electronics"}
-          ],
-          "settings": {
-            "timeout": 30,
-            "nested": {
-              "timeout": 60
-            }
-          }
-        }
-        "@
-
-        $testFile = "test-multiselect.json"
-        $multiSelectJson | Out-File -FilePath $testFile -Encoding UTF8
-
-        $data = Get-Content $testFile | ConvertFrom-Json
-
-        # Test 1: Verify multiple elements can be selected by category
-        $electronicsProducts = $data.products | Where-Object { $_.category -eq "electronics" }
-        if ($electronicsProducts.Count -eq 3) {
-          Write-Host "✓ Filter by category works (found 3 electronics products)"
-        } else {
-          Write-Error "✗ Filter by category failed (expected 3, found $($electronicsProducts.Count))"
-          exit 1
-        }
-
-        # Test 2: Verify filter by price range
-        $expensiveProducts = $data.products | Where-Object { $_.price -gt 20 }
-        if ($expensiveProducts.Count -eq 2) {
-          Write-Host "✓ Filter by price range works (found 2 products > 20)"
-        } else {
-          Write-Error "✗ Filter by price range failed (expected 2, found $($expensiveProducts.Count))"
-          exit 1
-        }
-
-        # Test 3: Verify recursive descent (all timeout values)
-        $timeoutCount = 0
-        if ($data.settings.timeout) { $timeoutCount++ }
-        if ($data.settings.nested.timeout) { $timeoutCount++ }
-
-        if ($timeoutCount -eq 2) {
-          Write-Host "✓ Recursive descent works (found 2 timeout properties)"
-        } else {
-          Write-Error "✗ Recursive descent failed (expected 2, found $timeoutCount)"
-          exit 1
-        }
-
-        Write-Host "All multi-select and filter tests passed!"
+        if ($script:failed) { exit 1 }
 
     - name: Summary
       shell: pwsh
@@ -504,13 +343,16 @@ jobs:
         Write-Host "========================================" -ForegroundColor Green
         Write-Host "  Regression Test Summary" -ForegroundColor Green
         Write-Host "========================================" -ForegroundColor Green
-        Write-Host "✓ Solution build successful" -ForegroundColor Green
-        Write-Host "✓ Test installer built successfully" -ForegroundColor Green
-        Write-Host "✓ JSON validation tests passed" -ForegroundColor Green
-        Write-Host "✓ Non-ASCII JSON value tests passed" -ForegroundColor Green
-        Write-Host "✓ Common .NET patterns validated" -ForegroundColor Green
-        Write-Host "✓ JSONPath patterns validated" -ForegroundColor Green
-        Write-Host "✓ distinctValues action tests passed" -ForegroundColor Green
-        Write-Host "✓ OnlyIfExists attribute tests passed" -ForegroundColor Green
-        Write-Host "✓ Multi-select and filter tests passed" -ForegroundColor Green
+        Write-Host "✓ Solution + test installer built" -ForegroundColor Green
+        Write-Host "✓ readValue (happy + missing -> default)" -ForegroundColor Green
+        Write-Host "✓ setValue (filter, nested, multi-select, OnlyIfExists)" -ForegroundColor Green
+        Write-Host "✓ replaceJsonValue" -ForegroundColor Green
+        Write-Host "✓ createJsonPointerValue (new path + build from {})" -ForegroundColor Green
+        Write-Host "✓ deleteValue (wildcard)" -ForegroundColor Green
+        Write-Host "✓ appendArray / insertArray / removeArrayElement" -ForegroundColor Green
+        Write-Host "✓ distinctValues" -ForegroundColor Green
+        Write-Host "✓ validateSchema (happy + sad)" -ForegroundColor Green
+        Write-Host "✓ OnlyIfExists (update existing + skip missing)" -ForegroundColor Green
+        Write-Host "✓ non-ASCII (UTF-8) value preservation" -ForegroundColor Green
+        Write-Host "✓ invalid JSON aborts install" -ForegroundColor Green
         Write-Host "========================================" -ForegroundColor Green

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -120,8 +120,18 @@ jobs:
           }
         }
         "@
-        $source | Out-File -FilePath (Join-Path $dir "read-source.json") -Encoding UTF8
-        Write-Host "✓ Created C:\JsonRegression\read-source.json"
+        $readSrc = Join-Path $dir "read-source.json"
+        $source | Out-File -FilePath $readSrc -Encoding UTF8
+
+        # Validate the fixture up front so a setup failure here is never mistaken for a readValue
+        # custom-action bug later (readValue silently leaves the property unset if the file is absent).
+        if (-not (Test-Path $readSrc)) { Write-Host "✗ Failed to create $readSrc"; exit 1 }
+        $probe = Get-Content -Path $readSrc -Raw -Encoding UTF8 | ConvertFrom-Json
+        if ($probe.config.environment -ne 'Staging') {
+          Write-Host "✗ read-source.json does not contain the expected \$.config.environment = 'Staging'"
+          exit 1
+        }
+        Write-Host "✓ Created and verified $readSrc"
 
     - name: Install test MSI (happy path)
       shell: pwsh

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -10,6 +10,8 @@ on:
 env:
   SOLUTION_FILE_PATH: .
   BUILD_CONFIGURATION: Release
+  # ProductCode of TestJsonConfigInstaller (see TestJsonConfigInstaller/Product.wxs).
+  PRODUCT_CODE: "{C9A3F6AF-7F4F-473F-BFFC-6143EB1AA0D4}"
 
 permissions:
   contents: read
@@ -95,21 +97,14 @@ jobs:
     # End-to-end flag-type regression coverage.
     #
     # These steps install the real test MSI and assert the *extension's* behaviour
-    # by inspecting the JSON files it writes (and the install log). Every JsonFile
-    # action/flag is exercised, with both happy and sad paths:
+    # by inspecting the JSON files it writes (and, where there is no file artifact,
+    # the install log). Each individual check and its outcome is also written to the
+    # GitHub job summary so the run reports exactly which tests ran and passed/failed.
     #
-    #   readValue              - happy + missing element -> DefaultValue
-    #   setValue               - filtered, nested, multi-select, + OnlyIfExists
-    #   replaceJsonValue       - replace whole array from a property
-    #   createJsonPointerValue - create new paths / build a file from {}
-    #   deleteValue            - wildcard delete
-    #   appendArray            - append element
-    #   insertArray            - insert at index 0
-    #   removeArrayElement     - JSONPath filter delete
-    #   distinctValues         - de-duplicate arrays
-    #   validateSchema         - happy (passes) + sad (install fails)
-    #   OnlyIfExists           - update existing + skip missing
-    #   invalid JSON           - sad path (install fails)
+    # Coverage (happy + sad/variation) for every JsonFile flag:
+    #   readValue, setValue, replaceJsonValue, createJsonPointerValue, deleteValue,
+    #   appendArray, insertArray (Index 0 and -1), removeArrayElement, distinctValues,
+    #   validateSchema, OnlyIfExists, non-ASCII values, invalid JSON.
     # ---------------------------------------------------------------------------
 
     - name: Prepare readValue source file
@@ -133,11 +128,20 @@ jobs:
     - name: Install test MSI (happy path)
       shell: pwsh
       run: |
+        function Note([string]$line) { $line | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8 }
+        Note "# Regression Test Report"
+        Note ""
+        Note "## Install (happy path)"
+        Note ""
+        Note "| Result | Check |"
+        Note "| --- | --- |"
+
         $msi = (Get-ChildItem -Path "TestJsonConfigInstaller\bin" -Filter "*.msi" -Recurse | Select-Object -First 1).FullName
-        if (-not $msi) { Write-Host "✗ Test installer MSI not found"; exit 1 }
+        if (-not $msi) { Note "| ❌ | Test installer MSI not found |"; Write-Host "✗ MSI not found"; exit 1 }
         Write-Host "Installing: $msi"
 
         $log = Join-Path $env:RUNNER_TEMP "happy-install.log"
+        Remove-Item -Path $log -ErrorAction SilentlyContinue
 
         # MY_VALUE uses Cyrillic text to also regression-test non-ASCII (UTF-8) value handling.
         # Passing it as its own Start-Process argument keeps it Unicode-safe.
@@ -146,20 +150,31 @@ jobs:
         $p = Start-Process -FilePath "msiexec.exe" -ArgumentList $argline -Wait -PassThru
         Write-Host "msiexec exit code: $($p.ExitCode)"
 
-        if ($p.ExitCode -ne 0 -and $p.ExitCode -ne 3010) {
+        if ($p.ExitCode -eq 0 -or $p.ExitCode -eq 3010) {
+          Note "| ✅ | MSI install succeeded (exit $($p.ExitCode)) |"
+          Write-Host "✓ Happy-path install succeeded"
+        } else {
+          Note "| ❌ | MSI install failed (exit $($p.ExitCode)) |"
           Write-Host "✗ Happy-path install failed"
           if (Test-Path $log) { Write-Host "----- msiexec log -----"; Get-Content -Path $log }
           exit 1
         }
-        Write-Host "✓ Happy-path install succeeded"
 
     - name: Verify all flag types in installed JSON (happy paths)
       shell: pwsh
       run: |
         $failed = $false
+        function Note([string]$line) { $line | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8 }
         function Check([bool]$cond, [string]$msg) {
-          if ($cond) { Write-Host "  [PASS] $msg" } else { Write-Host "  [FAIL] $msg"; $script:failed = $true }
+          if ($cond) { Write-Host "  [PASS] $msg"; Note "| ✅ | $msg |" }
+          else { Write-Host "  [FAIL] $msg"; Note "| ❌ | $msg |"; $script:failed = $true }
         }
+
+        Note ""
+        Note "## Installed-JSON flag-type assertions"
+        Note ""
+        Note "| Result | Check |"
+        Note "| --- | --- |"
 
         $expectedCategory = "КатегорияПривет"
         $installDir = Join-Path $env:ProgramFiles "TestJsonConfigInstaller"
@@ -169,7 +184,7 @@ jobs:
         $setPath = Join-Path $installDir "settings.json"
 
         foreach ($f in @($appPath, $cfgPath, $setPath)) {
-          if (-not (Test-Path $f)) { Write-Host "✗ Expected installed file missing: $f"; exit 1 }
+          if (-not (Test-Path $f)) { Note "| ❌ | Expected installed file missing: $f |"; Write-Host "✗ Missing $f"; exit 1 }
         }
 
         $j = Get-Content -Path $appPath -Raw -Encoding UTF8 | ConvertFrom-Json
@@ -177,20 +192,28 @@ jobs:
         Write-Host "replaceJsonValue / setValue (filter) / non-ASCII:"
         $books = @($j.store.book)
         $moby = $books | Where-Object { $_.isbn -eq '0-553-21311-3' } | Select-Object -First 1
-        Check ($null -ne $moby) "book with isbn 0-553-21311-3 exists after replaceJsonValue"
+        Check ($null -ne $moby) "replaceJsonValue: book with isbn 0-553-21311-3 exists"
         Check ($moby.author -eq 'HermanMelville') "replaceJsonValue replaced array contents from MY_BOOKS"
         Check ($moby.category -eq $expectedCategory) "setValue (JSONPath filter) wrote non-ASCII value to category"
 
-        Write-Host "appendArray / insertArray / removeArrayElement:"
-        Check ($books.Count -eq 3) "net array size is 3 (append + insert at 0 - remove price>20)"
+        Write-Host "appendArray / insertArray / removeArrayElement (on store.book):"
+        Check ($books.Count -eq 3) "net array size is 3 (append + insert@0 - remove price>20)"
         Check ($books[0].title -eq 'Steve Jobs') "insertArray placed 'Steve Jobs' at index 0"
         Check ((@($books | Where-Object { $_.title -eq 'Cosmos' })).Count -eq 1) "appendArray added 'Cosmos'"
         Check ((@($books | Where-Object { $_.author -eq 'NigelRees' })).Count -eq 0) "removeArrayElement removed books priced > 20"
 
+        Write-Host "insertArray Index variations / appendArray (on isolated arrayOps):"
+        $ao = @($j.arrayOps)
+        Check ($ao.Count -eq 4) "arrayOps has 4 elements after insert(0)/insert(-1)/append"
+        Check ($ao[0] -eq 'first') "insertArray Index=0 inserted 'first' at front"
+        Check ($ao[1] -eq 'seed') "original 'seed' element retained in order"
+        Check ($ao[2] -eq 'last') "insertArray Index=-1 appended 'last'"
+        Check ($ao[3] -eq 'appended') "appendArray added 'appended' at the end"
+
         Write-Host "setValue (multi-select recursive descent):"
         $prices = @($books.price) + @($j.store.bicycle.price)
         $offPrice = @($prices | Where-Object { [math]::Abs([double]$_ - 9.99) -gt 0.001 })
-        Check ($offPrice.Count -eq 0) "`$..price multi-select set every price to 9.99"
+        Check ($offPrice.Count -eq 0) "`$..price multi-select set every price (books + bicycle) to 9.99"
 
         Write-Host "deleteValue (wildcard):"
         $withOldPrice = @($books | Where-Object { $_.PSObject.Properties.Name -contains 'OldPrice' })
@@ -201,8 +224,7 @@ jobs:
 
         Write-Host "setValue (deeply nested) using LOG_DIRECTORY property:"
         $logPath = $j.Serilog.WriteTo[0].Args.configure[0].Args.path
-        Check ($logPath -like 'C:\temp\*') "nested setValue substituted [LOG_DIRECTORY]"
-        Check ($logPath -like '*PowerCommunications*') "nested setValue preserved path suffix"
+        Check ($logPath -like 'C:\temp\PowerCommunications*CommunicationService.Outgoing-.log') "nested setValue substituted [LOG_DIRECTORY] and kept the literal suffix"
 
         Write-Host "OnlyIfExists:"
         Check ($j.expensive -eq 15) "OnlyIfExists=yes updated existing 'expensive' to 15"
@@ -225,100 +247,142 @@ jobs:
         Check ($set.Application.Version -eq '2.0.0') "built Application.Version from empty file"
         Check ($set.Logging.Level -eq 'Debug') "built Logging.Level from empty file"
 
+        Write-Host "readValue (verified via written-back file content):"
+        Check ($set.ReadResults.Present -eq 'Staging') "readValue read existing element ('Staging') -> written back to file"
+        Check ($set.ReadResults.Missing -eq 'READ_DEFAULT') "readValue applied DefaultValue for missing element -> written back to file"
+
         if ($script:failed) { Write-Host "`nOne or more flag-type assertions FAILED"; exit 1 }
         Write-Host "`n✓ All installed-JSON flag-type assertions passed"
 
-    - name: Verify readValue and validateSchema (from install log)
+    - name: Verify validateSchema (happy path) from install log
       shell: pwsh
       run: |
         $failed = $false
+        function Note([string]$line) { $line | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8 }
         function Check([bool]$cond, [string]$msg) {
-          if ($cond) { Write-Host "  [PASS] $msg" } else { Write-Host "  [FAIL] $msg"; $script:failed = $true }
+          if ($cond) { Write-Host "  [PASS] $msg"; Note "| ✅ | $msg |" }
+          else { Write-Host "  [FAIL] $msg"; Note "| ❌ | $msg |"; $script:failed = $true }
         }
 
+        Note ""
+        Note "## validateSchema (happy path)"
+        Note ""
+        Note "| Result | Check |"
+        Note "| --- | --- |"
+
         $log = Join-Path $env:RUNNER_TEMP "happy-install.log"
-        if (-not (Test-Path $log)) { Write-Host "✗ Install log not found: $log"; exit 1 }
+        if (-not (Test-Path $log)) { Note "| ❌ | Install log not found |"; Write-Host "✗ log missing"; exit 1 }
         $content = Get-Content -Path $log -Raw
 
-        Write-Host "readValue:"
-        Check ($content -match "REG_READ_PRESENT.*Staging") "readValue read existing value ('Staging') into a property"
-        Check ($content -match "REG_READ_MISSING.*READ_DEFAULT") "readValue applied DefaultValue for a missing element"
+        # The validator logs this only when SchemaFile validation actually ran and passed.
+        Check ($content -match [regex]::Escape("JSON schema validation successful")) "SchemaFile validation passed for the valid file"
 
-        Write-Host "validateSchema (happy):"
-        Check ($content -match "JSON schema validation successful") "SchemaFile validation passed for the valid file"
-
-        if ($script:failed) { Write-Host "`nreadValue/validateSchema log assertions FAILED"; exit 1 }
-        Write-Host "`n✓ readValue and validateSchema (happy) assertions passed"
+        if ($script:failed) { exit 1 }
+        Write-Host "`n✓ validateSchema (happy) assertion passed"
 
     - name: Uninstall happy-path product
       shell: pwsh
       run: |
         $log = Join-Path $env:RUNNER_TEMP "uninstall.log"
-        $p = Start-Process -FilePath "msiexec.exe" -ArgumentList "/x {C9A3F6AF-7F4F-473F-BFFC-6143EB1AA0D4} /qn /norestart /l*v `"$log`"" -Wait -PassThru
+        Remove-Item -Path $log -ErrorAction SilentlyContinue
+        $p = Start-Process -FilePath "msiexec.exe" -ArgumentList "/x `"$env:PRODUCT_CODE`" /qn /norestart /l*v `"$log`"" -Wait -PassThru
         Write-Host "Uninstall exit code: $($p.ExitCode)"
 
     - name: Sad path - invalid JSON aborts install
       shell: pwsh
       run: |
+        $failed = $false
+        function Note([string]$line) { $line | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8 }
+        function Check([bool]$cond, [string]$msg) {
+          if ($cond) { Write-Host "  [PASS] $msg"; Note "| ✅ | $msg |" }
+          else { Write-Host "  [FAIL] $msg"; Note "| ❌ | $msg |"; $script:failed = $true }
+        }
+
+        Note ""
+        Note "## Sad path: invalid JSON aborts install"
+        Note ""
+        Note "| Result | Check |"
+        Note "| --- | --- |"
+
         $msi = (Get-ChildItem -Path "TestJsonConfigInstaller\bin" -Filter "*.msi" -Recurse | Select-Object -First 1).FullName
         $log = Join-Path $env:RUNNER_TEMP "invalid-json.log"
+        Remove-Item -Path $log -ErrorAction SilentlyContinue
 
         # TEST_INVALID_JSON=1 enables a component that operates on malformed JSON; the custom action
         # must fail, which aborts and rolls back the installation.
         $p = Start-Process -FilePath "msiexec.exe" -ArgumentList "/i `"$msi`" /qn /norestart /l*v `"$log`" TEST_INVALID_JSON=1" -Wait -PassThru
         Write-Host "msiexec exit code: $($p.ExitCode)"
 
-        if ($p.ExitCode -eq 0 -or $p.ExitCode -eq 3010) {
-          Write-Host "✗ Install unexpectedly SUCCEEDED with invalid JSON (expected failure)"
-          # Best-effort cleanup so later steps start clean.
-          Start-Process -FilePath "msiexec.exe" -ArgumentList "/x {C9A3F6AF-7F4F-473F-BFFC-6143EB1AA0D4} /qn /norestart" -Wait | Out-Null
-          exit 1
-        }
-        Write-Host "✓ Invalid JSON correctly aborted the install (exit $($p.ExitCode))"
+        $nonZero = ($p.ExitCode -ne 0 -and $p.ExitCode -ne 3010)
+        Check $nonZero "install failed as expected (exit $($p.ExitCode))"
 
-        if (Test-Path $log) {
-          $content = Get-Content -Path $log -Raw
-          if ($content -match "invalid.json") {
-            Write-Host "✓ Install log references the invalid JSON file"
-          } else {
-            Write-Host "  (note: invalid.json not referenced in log; relying on non-zero exit code)"
-          }
+        # Prove the failure was actually the JSON operation, not an unrelated error.
+        $content = if (Test-Path $log) { Get-Content -Path $log -Raw } else { "" }
+        Check ($content -match [regex]::Escape("Failed while updating file")) "extension reported a JsonFile operation failure"
+        Check ($content -match "invalid\.json") "the failing operation targeted invalid.json"
+
+        # Best-effort cleanup in case the install unexpectedly succeeded.
+        if (-not $nonZero) {
+          Start-Process -FilePath "msiexec.exe" -ArgumentList "/x `"$env:PRODUCT_CODE`" /qn /norestart" -Wait | Out-Null
         }
+
+        if ($script:failed) { Write-Host "`nInvalid-JSON sad-path assertions FAILED"; exit 1 }
+        Write-Host "`n✓ Invalid JSON correctly aborted the install for the right reason"
 
     - name: Sad path - schema validation failure aborts install
       shell: pwsh
       run: |
+        $failed = $false
+        function Note([string]$line) { $line | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8 }
+        function Check([bool]$cond, [string]$msg) {
+          if ($cond) { Write-Host "  [PASS] $msg"; Note "| ✅ | $msg |" }
+          else { Write-Host "  [FAIL] $msg"; Note "| ❌ | $msg |"; $script:failed = $true }
+        }
+
+        Note ""
+        Note "## Sad path: schema validation failure aborts install"
+        Note ""
+        Note "| Result | Check |"
+        Note "| --- | --- |"
+
         $msi = (Get-ChildItem -Path "TestJsonConfigInstaller\bin" -Filter "*.msi" -Recurse | Select-Object -First 1).FullName
         $log = Join-Path $env:RUNNER_TEMP "schema-failure.log"
+        Remove-Item -Path $log -ErrorAction SilentlyContinue
 
         # TEST_SCHEMA_FAILURE=1 enables a component whose JSON is valid but violates the schema
         # (missing required "store"); schema validation must fail and abort the install.
         $p = Start-Process -FilePath "msiexec.exe" -ArgumentList "/i `"$msi`" /qn /norestart /l*v `"$log`" TEST_SCHEMA_FAILURE=1" -Wait -PassThru
         Write-Host "msiexec exit code: $($p.ExitCode)"
 
-        if ($p.ExitCode -eq 0 -or $p.ExitCode -eq 3010) {
-          Write-Host "✗ Install unexpectedly SUCCEEDED despite schema violation (expected failure)"
-          Start-Process -FilePath "msiexec.exe" -ArgumentList "/x {C9A3F6AF-7F4F-473F-BFFC-6143EB1AA0D4} /qn /norestart" -Wait | Out-Null
-          exit 1
-        }
-        Write-Host "✓ Schema violation correctly aborted the install (exit $($p.ExitCode))"
+        $nonZero = ($p.ExitCode -ne 0 -and $p.ExitCode -ne 3010)
+        Check $nonZero "install failed as expected (exit $($p.ExitCode))"
 
-        if (Test-Path $log) {
-          $content = Get-Content -Path $log -Raw
-          if ($content -match "Schema validation failed" -or $content -match "Required property missing") {
-            Write-Host "✓ Install log shows the schema validation failure"
-          } else {
-            Write-Host "  (note: schema failure message not found in log; relying on non-zero exit code)"
-          }
+        # Prove the failure was specifically schema validation, not an unrelated error.
+        $content = if (Test-Path $log) { Get-Content -Path $log -Raw } else { "" }
+        Check ($content -match [regex]::Escape("Schema validation failed")) "extension reported a schema validation failure"
+
+        if (-not $nonZero) {
+          Start-Process -FilePath "msiexec.exe" -ArgumentList "/x `"$env:PRODUCT_CODE`" /qn /norestart" -Wait | Out-Null
         }
+
+        if ($script:failed) { Write-Host "`nSchema-failure sad-path assertions FAILED"; exit 1 }
+        Write-Host "`n✓ Schema violation correctly aborted the install for the right reason"
 
     - name: Verify repository test JSON fixtures
       shell: pwsh
       run: |
         $failed = $false
+        function Note([string]$line) { $line | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8 }
         function Check([bool]$cond, [string]$msg) {
-          if ($cond) { Write-Host "  [PASS] $msg" } else { Write-Host "  [FAIL] $msg"; $script:failed = $true }
+          if ($cond) { Write-Host "  [PASS] $msg"; Note "| ✅ | $msg |" }
+          else { Write-Host "  [FAIL] $msg"; Note "| ❌ | $msg |"; $script:failed = $true }
         }
+
+        Note ""
+        Note "## Repository JSON fixtures"
+        Note ""
+        Note "| Result | Check |"
+        Note "| --- | --- |"
 
         # Valid fixtures should parse.
         foreach ($f in @("TestJsonConfigInstaller\appsettings.json", "TestJsonConfigInstaller\appsettings.dotnet.json")) {
@@ -336,23 +400,11 @@ jobs:
 
         if ($script:failed) { exit 1 }
 
-    - name: Summary
+    - name: Report overall result
+      if: always()
       shell: pwsh
       run: |
-        Write-Host ""
-        Write-Host "========================================" -ForegroundColor Green
-        Write-Host "  Regression Test Summary" -ForegroundColor Green
-        Write-Host "========================================" -ForegroundColor Green
-        Write-Host "✓ Solution + test installer built" -ForegroundColor Green
-        Write-Host "✓ readValue (happy + missing -> default)" -ForegroundColor Green
-        Write-Host "✓ setValue (filter, nested, multi-select, OnlyIfExists)" -ForegroundColor Green
-        Write-Host "✓ replaceJsonValue" -ForegroundColor Green
-        Write-Host "✓ createJsonPointerValue (new path + build from {})" -ForegroundColor Green
-        Write-Host "✓ deleteValue (wildcard)" -ForegroundColor Green
-        Write-Host "✓ appendArray / insertArray / removeArrayElement" -ForegroundColor Green
-        Write-Host "✓ distinctValues" -ForegroundColor Green
-        Write-Host "✓ validateSchema (happy + sad)" -ForegroundColor Green
-        Write-Host "✓ OnlyIfExists (update existing + skip missing)" -ForegroundColor Green
-        Write-Host "✓ non-ASCII (UTF-8) value preservation" -ForegroundColor Green
-        Write-Host "✓ invalid JSON aborts install" -ForegroundColor Green
-        Write-Host "========================================" -ForegroundColor Green
+        function Note([string]$line) { $line | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8 }
+        Note ""
+        Note "## Overall result: ${{ job.status }}"
+        Write-Host "Overall job status: ${{ job.status }}"

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -10,8 +10,6 @@ on:
 env:
   SOLUTION_FILE_PATH: .
   BUILD_CONFIGURATION: Release
-  # ProductCode of TestJsonConfigInstaller (see TestJsonConfigInstaller/Product.wxs).
-  PRODUCT_CODE: "{C9A3F6AF-7F4F-473F-BFFC-6143EB1AA0D4}"
 
 permissions:
   contents: read
@@ -283,10 +281,17 @@ jobs:
     - name: Uninstall happy-path product
       shell: pwsh
       run: |
+        # Uninstall via the package path (no ProductCode coupling that could drift from Product.wxs).
+        $msi = (Get-ChildItem -Path "TestJsonConfigInstaller\bin" -Filter "*.msi" -Recurse | Select-Object -First 1).FullName
         $log = Join-Path $env:RUNNER_TEMP "uninstall.log"
         Remove-Item -Path $log -ErrorAction SilentlyContinue
-        $p = Start-Process -FilePath "msiexec.exe" -ArgumentList "/x `"$env:PRODUCT_CODE`" /qn /norestart /l*v `"$log`"" -Wait -PassThru
+        $p = Start-Process -FilePath "msiexec.exe" -ArgumentList "/x `"$msi`" /qn /norestart /l*v `"$log`"" -Wait -PassThru
         Write-Host "Uninstall exit code: $($p.ExitCode)"
+        if ($p.ExitCode -ne 0 -and $p.ExitCode -ne 3010) {
+          Write-Host "✗ Uninstall failed; later install steps may be affected"
+          if (Test-Path $log) { Get-Content -Path $log }
+          exit 1
+        }
 
     - name: Sad path - invalid JSON aborts install
       shell: pwsh
@@ -323,7 +328,7 @@ jobs:
 
         # Best-effort cleanup in case the install unexpectedly succeeded.
         if (-not $nonZero) {
-          Start-Process -FilePath "msiexec.exe" -ArgumentList "/x `"$env:PRODUCT_CODE`" /qn /norestart" -Wait | Out-Null
+          Start-Process -FilePath "msiexec.exe" -ArgumentList "/x `"$msi`" /qn /norestart" -Wait | Out-Null
         }
 
         if ($script:failed) { Write-Host "`nInvalid-JSON sad-path assertions FAILED"; exit 1 }
@@ -362,7 +367,7 @@ jobs:
         Check ($content -match [regex]::Escape("Schema validation failed")) "extension reported a schema validation failure"
 
         if (-not $nonZero) {
-          Start-Process -FilePath "msiexec.exe" -ArgumentList "/x `"$env:PRODUCT_CODE`" /qn /norestart" -Wait | Out-Null
+          Start-Process -FilePath "msiexec.exe" -ArgumentList "/x `"$msi`" /qn /norestart" -Wait | Out-Null
         }
 
         if ($script:failed) { Write-Host "`nSchema-failure sad-path assertions FAILED"; exit 1 }

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -281,13 +281,23 @@ jobs:
     - name: Uninstall happy-path product
       shell: pwsh
       run: |
+        function Note([string]$line) { $line | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8 }
+        Note ""
+        Note "## Uninstall (happy path)"
+        Note ""
+        Note "| Result | Check |"
+        Note "| --- | --- |"
+
         # Uninstall via the package path (no ProductCode coupling that could drift from Product.wxs).
         $msi = (Get-ChildItem -Path "TestJsonConfigInstaller\bin" -Filter "*.msi" -Recurse | Select-Object -First 1).FullName
         $log = Join-Path $env:RUNNER_TEMP "uninstall.log"
         Remove-Item -Path $log -ErrorAction SilentlyContinue
         $p = Start-Process -FilePath "msiexec.exe" -ArgumentList "/x `"$msi`" /qn /norestart /l*v `"$log`"" -Wait -PassThru
         Write-Host "Uninstall exit code: $($p.ExitCode)"
-        if ($p.ExitCode -ne 0 -and $p.ExitCode -ne 3010) {
+        if ($p.ExitCode -eq 0 -or $p.ExitCode -eq 3010) {
+          Note "| ✅ | MSI uninstall succeeded (exit $($p.ExitCode)) |"
+        } else {
+          Note "| ❌ | MSI uninstall failed (exit $($p.ExitCode)) — later steps may be affected |"
           Write-Host "✗ Uninstall failed; later install steps may be affected"
           if (Test-Path $log) { Get-Content -Path $log }
           exit 1

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -108,6 +108,14 @@ jobs:
     - name: Prepare readValue source file
       shell: pwsh
       run: |
+        function Note([string]$line) { $line | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8 }
+        Note "# Regression Test Report"
+        Note ""
+        Note "## Setup"
+        Note ""
+        Note "| Result | Check |"
+        Note "| --- | --- |"
+
         # readValue (WixPropertyJsonFile) runs after CostFinalize, i.e. BEFORE InstallFiles, so it
         # cannot read a file installed in the same transaction. The test installer therefore reads
         # this pre-existing file from a fixed location.
@@ -125,19 +133,24 @@ jobs:
 
         # Validate the fixture up front so a setup failure here is never mistaken for a readValue
         # custom-action bug later (readValue silently leaves the property unset if the file is absent).
-        if (-not (Test-Path $readSrc)) { Write-Host "✗ Failed to create $readSrc"; exit 1 }
-        $probe = Get-Content -Path $readSrc -Raw -Encoding UTF8 | ConvertFrom-Json
-        if ($probe.config.environment -ne 'Staging') {
-          Write-Host "✗ read-source.json does not contain the expected \$.config.environment = 'Staging'"
+        $ok = (Test-Path $readSrc)
+        if ($ok) {
+          $probe = Get-Content -Path $readSrc -Raw -Encoding UTF8 | ConvertFrom-Json
+          $ok = ($probe.config.environment -eq 'Staging')
+        }
+        if ($ok) {
+          Note "| ✅ | Created and verified readValue source ($readSrc) |"
+          Write-Host "✓ Created and verified $readSrc"
+        } else {
+          Note "| ❌ | Failed to create/verify readValue source ($readSrc) |"
+          Write-Host "✗ Failed to create/verify $readSrc"
           exit 1
         }
-        Write-Host "✓ Created and verified $readSrc"
 
     - name: Install test MSI (happy path)
       shell: pwsh
       run: |
         function Note([string]$line) { $line | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8 }
-        Note "# Regression Test Report"
         Note ""
         Note "## Install (happy path)"
         Note ""

--- a/TESTING.md
+++ b/TESTING.md
@@ -356,7 +356,7 @@ log). Every JsonFile action/flag is exercised with both happy and sad paths:
 | `createJsonPointerValue` | creates a new top-level path; builds a whole file from `{}` | — |
 | `deleteValue` | wildcard delete across an array | — |
 | `appendArray` | appends an element | — |
-| `insertArray` | inserts at index 0 | — |
+| `insertArray` | inserts at index 0 | append via `Index="-1"` |
 | `removeArrayElement` | removes elements via a JSONPath filter | — |
 | `distinctValues` | de-duplicates string arrays | — |
 | `validateSchema` (`SchemaFile`) | passes for a valid file | schema violation aborts the install |
@@ -368,12 +368,19 @@ Sad paths that must abort the installation are driven by gated components in
 `TestJsonConfigInstaller/Product.wxs`, enabled per-run via installer properties
 (`TEST_INVALID_JSON=1`, `TEST_SCHEMA_FAILURE=1`) so they never affect a normal install.
 
+`readValue` is verified end-to-end by writing the read result back into an installed file and
+asserting that file's content (rather than relying on installer log wording). Every individual
+check and its pass/fail outcome is also written to the GitHub Actions job summary, so each run
+reports exactly which tests ran and their end state.
+
 The high-level steps are:
 
 1. Build the solution and the test installer
 2. Install the MSI (happy path) and assert every flag type against the installed JSON
-3. Verify `readValue` and `validateSchema` outcomes from the install log
-4. Run the invalid-JSON and schema-failure installs and confirm they fail and roll back
+   (including `readValue` results written back into `settings.json`)
+3. Verify the `validateSchema` happy path from the install log
+4. Run the invalid-JSON and schema-failure installs and confirm they fail, for the right
+   reason, and roll back
 5. Sanity-check the repository's JSON fixtures
 
 These tests run automatically on:

--- a/TESTING.md
+++ b/TESTING.md
@@ -343,13 +343,38 @@ Test with various application configurations:
 
 ## Automated Testing with CI
 
-The project includes automated regression tests in `.github/workflows/regression-tests.yml` that:
+The project includes automated regression tests in `.github/workflows/regression-tests.yml`.
+Rather than re-implementing JSON semantics in PowerShell, these tests **install the real test
+MSI** and assert the extension's behaviour by inspecting the JSON files it writes (and the install
+log). Every JsonFile action/flag is exercised with both happy and sad paths:
 
-1. Build the solution
-2. Build the test installer
-3. Validate JSON syntax
-4. Test common .NET patterns
-5. Test JSONPath patterns
+| Flag / action | Happy path | Sad / variation path |
+| --- | --- | --- |
+| `readValue` | reads an existing value into a property | missing element falls back to `DefaultValue` |
+| `setValue` | JSONPath filter, deeply nested path, recursive-descent multi-select | combined with `OnlyIfExists` |
+| `replaceJsonValue` | replaces an entire array from an installer property | — |
+| `createJsonPointerValue` | creates a new top-level path; builds a whole file from `{}` | — |
+| `deleteValue` | wildcard delete across an array | — |
+| `appendArray` | appends an element | — |
+| `insertArray` | inserts at index 0 | — |
+| `removeArrayElement` | removes elements via a JSONPath filter | — |
+| `distinctValues` | de-duplicates string arrays | — |
+| `validateSchema` (`SchemaFile`) | passes for a valid file | schema violation aborts the install |
+| `OnlyIfExists` | updates an existing element | skips a missing element |
+| non-ASCII values | UTF-8 (Cyrillic) value is preserved | — |
+| invalid JSON | — | malformed JSON aborts the install |
+
+Sad paths that must abort the installation are driven by gated components in
+`TestJsonConfigInstaller/Product.wxs`, enabled per-run via installer properties
+(`TEST_INVALID_JSON=1`, `TEST_SCHEMA_FAILURE=1`) so they never affect a normal install.
+
+The high-level steps are:
+
+1. Build the solution and the test installer
+2. Install the MSI (happy path) and assert every flag type against the installed JSON
+3. Verify `readValue` and `validateSchema` outcomes from the install log
+4. Run the invalid-JSON and schema-failure installs and confirm they fail and roll back
+5. Sanity-check the repository's JSON fixtures
 
 These tests run automatically on:
 - Every push to main

--- a/TestJsonConfigInstaller/Product.wxs
+++ b/TestJsonConfigInstaller/Product.wxs
@@ -14,13 +14,15 @@
     <Property Id="LOG_DIRECTORY" Value="C:\temp\" />
 
     <!-- readValue source path is overridable; defaults to the location the regression workflow
-         populates. The two REG_READ_* properties get sensible defaults so that if the source file
-         is absent at install time (readValue leaves the property untouched when the whole file is
-         missing, as opposed to applying DefaultValue when only the element is missing), the
-         downstream write-back still produces a deterministic value. -->
+         populates. The two REG_READ_* properties default to a distinct sentinel (NOT the readValue
+         DefaultValue) so the regression assertions can tell apart three cases: the element was read
+         ("Staging"), the element was missing and DefaultValue was applied ("READ_DEFAULT"), or the
+         readValue action never ran / the source file was absent ("PROPERTY_NOT_SET"). Using the
+         sentinel here prevents a false pass where readValue silently doing nothing would still
+         leave the expected default value in the property. -->
     <Property Id="REG_READ_SOURCE" Value="C:\JsonRegression\read-source.json" />
-    <Property Id="REG_READ_PRESENT" Value="READ_DEFAULT" />
-    <Property Id="REG_READ_MISSING" Value="READ_DEFAULT" />
+    <Property Id="REG_READ_PRESENT" Value="PROPERTY_NOT_SET" />
+    <Property Id="REG_READ_MISSING" Value="PROPERTY_NOT_SET" />
 
     <Feature Id="ProductFeature" Title="TestJsonConfigInstaller" Level="1">
       <ComponentGroupRef Id="ProductComponents" />

--- a/TestJsonConfigInstaller/Product.wxs
+++ b/TestJsonConfigInstaller/Product.wxs
@@ -13,6 +13,15 @@
     <Property Id="MY_BOOKS" Value="[{&quot;author&quot;:&quot;NigelRees&quot;,&quot;category&quot;:&quot;reference&quot;,&quot;price&quot;:28.95,&quot;OldPrice&quot;:128.95,&quot;title&quot;:&quot;SayingsoftheCentury&quot;},{&quot;author&quot;:&quot;EvelynWaugh&quot;,&quot;category&quot;:&quot;fiction&quot;,&quot;price&quot;:22.99,&quot;OldPrice&quot;:168.95,&quot;title&quot;:&quot;SwordofHonour&quot;},{&quot;author&quot;:&quot;HermanMelville&quot;,&quot;category&quot;:&quot;fiction&quot;,&quot;isbn&quot;:&quot;0-553-21311-3&quot;,&quot;price&quot;:28.99,&quot;OldPrice&quot;:178.95,&quot;title&quot;:&quot;MobyDick&quot;}]" />
     <Property Id="LOG_DIRECTORY" Value="C:\temp\" />
 
+    <!-- readValue source path is overridable; defaults to the location the regression workflow
+         populates. The two REG_READ_* properties get sensible defaults so that if the source file
+         is absent at install time (readValue leaves the property untouched when the whole file is
+         missing, as opposed to applying DefaultValue when only the element is missing), the
+         downstream write-back still produces a deterministic value. -->
+    <Property Id="REG_READ_SOURCE" Value="C:\JsonRegression\read-source.json" />
+    <Property Id="REG_READ_PRESENT" Value="READ_DEFAULT" />
+    <Property Id="REG_READ_MISSING" Value="READ_DEFAULT" />
+
     <Feature Id="ProductFeature" Title="TestJsonConfigInstaller" Level="1">
       <ComponentGroupRef Id="ProductComponents" />
     </Feature>
@@ -45,8 +54,8 @@
              machine rather than one being installed in this same transaction.
              REG_READ_PRESENT exercises the happy path; REG_READ_MISSING exercises the sad path where
              the element is absent and the DefaultValue is applied instead. -->
-        <Json:JsonFile Id="regReadPresent" File="C:\JsonRegression\read-source.json" ElementPath="$.config.environment" DefaultValue="READ_DEFAULT" Action="readValue" Property="REG_READ_PRESENT" />
-        <Json:JsonFile Id="regReadMissing" File="C:\JsonRegression\read-source.json" ElementPath="$.config.missingKey" DefaultValue="READ_DEFAULT" Action="readValue" Property="REG_READ_MISSING" />
+        <Json:JsonFile Id="regReadPresent" File="[REG_READ_SOURCE]" ElementPath="$.config.environment" DefaultValue="READ_DEFAULT" Action="readValue" Property="REG_READ_PRESENT" />
+        <Json:JsonFile Id="regReadMissing" File="[REG_READ_SOURCE]" ElementPath="$.config.missingKey" DefaultValue="READ_DEFAULT" Action="readValue" Property="REG_READ_MISSING" />
         
         <!-- Replace entire JSON object -->
         <Json:JsonFile Id="appSettingsSetBooks" File="[#JsonConfig]" ElementPath="$.store.book" Value="[MY_BOOKS]" Action="replaceJsonValue" Sequence="1" />
@@ -96,7 +105,10 @@
                Sequence="9"/>
 
         <!-- Update all prices (multi-select). SchemaFile validates the file against
-             appsettings-schema.json after this operation succeeds (validateSchema happy path). -->
+             appsettings-schema.json after this operation succeeds (validateSchema happy path).
+             Intentionally placed on a plain setValue (not an OnlyIfExists op): when OnlyIfExists
+             skips a missing path the operation short-circuits before schema validation runs, so
+             attaching SchemaFile here guarantees the validation actually executes. -->
         <Json:JsonFile Id="updateAllPrices"
                File="[#JsonConfig]"
                ElementPath="$..price"

--- a/TestJsonConfigInstaller/Product.wxs
+++ b/TestJsonConfigInstaller/Product.wxs
@@ -38,6 +38,15 @@
         <Json:JsonFile Id="appSettingsReadValue" File="[#JsonConfig]" ElementPath="$.store.book[\[]?(@.isbn == '0-553-21311-3')[\]].category" DefaultValue="Empty" Action="readValue" Property="MY_PROPERTY" />
 
         <Json:JsonFile Id="appSettingsReadMissingValue" File="[#JsonConfig]" ElementPath="$.store.book[\[]?(@.isbn == '0-553-21311-5')[\]].category" DefaultValue="MissingEmpty" Action="readValue" Property="MY_MISSING_PROPERTY" />
+
+        <!-- Regression: readValue reads from a pre-existing source file (created by the regression
+             workflow at C:\JsonRegression\read-source.json). The read custom action runs after
+             CostFinalize (before InstallFiles), so it must read a file that already exists on the
+             machine rather than one being installed in this same transaction.
+             REG_READ_PRESENT exercises the happy path; REG_READ_MISSING exercises the sad path where
+             the element is absent and the DefaultValue is applied instead. -->
+        <Json:JsonFile Id="regReadPresent" File="C:\JsonRegression\read-source.json" ElementPath="$.config.environment" DefaultValue="READ_DEFAULT" Action="readValue" Property="REG_READ_PRESENT" />
+        <Json:JsonFile Id="regReadMissing" File="C:\JsonRegression\read-source.json" ElementPath="$.config.missingKey" DefaultValue="READ_DEFAULT" Action="readValue" Property="REG_READ_MISSING" />
         
         <!-- Replace entire JSON object -->
         <Json:JsonFile Id="appSettingsSetBooks" File="[#JsonConfig]" ElementPath="$.store.book" Value="[MY_BOOKS]" Action="replaceJsonValue" Sequence="1" />
@@ -86,12 +95,14 @@
                Action="removeArrayElement"
                Sequence="9"/>
 
-        <!-- Update all prices (multi-select) -->
+        <!-- Update all prices (multi-select). SchemaFile validates the file against
+             appsettings-schema.json after this operation succeeds (validateSchema happy path). -->
         <Json:JsonFile Id="updateAllPrices"
                File="[#JsonConfig]"
                ElementPath="$..price"
                Value="9.99"
                Action="setValue"
+               SchemaFile="[#AppSettingsSchema]"
                Sequence="10"/>
 
         <!-- New: Remove duplicates from tags array -->
@@ -187,10 +198,44 @@
         <Json:JsonFile 
           Id="CreateLogLevel" 
           File="[#EmptyConfig]" 
-          ElementPath="/Logging/Level" 
-          Value="Debug" 
-          Action="createJsonPointerValue" 
+          ElementPath="/Logging/Level"
+          Value="Debug"
+          Action="createJsonPointerValue"
           Sequence="4" />
+      </Component>
+
+      <!-- Installs the JSON schema used for validateSchema coverage. Kept in its own component so
+           it can be referenced (via [#AppSettingsSchema]) by both the happy-path validation in
+           ProductComponent and the schema-failure regression component below. -->
+      <Component Id="SchemaFileComponent" Guid="{58862E01-A058-4CB1-9FA3-66D81F5F6639}">
+        <File Id="AppSettingsSchema" Name="appsettings-schema.json" Source="appsettings-schema.json" KeyPath="yes" />
+      </Component>
+
+      <!-- Sad path: invalid JSON. Only installed when TEST_INVALID_JSON=1 is passed on the command
+           line. Attempting any operation on a malformed JSON file makes the custom action fail,
+           which aborts and rolls back the installation. -->
+      <Component Id="InvalidJsonComponent" Guid="{80054463-0503-45B7-8053-224623D99684}" Condition="TEST_INVALID_JSON=1">
+        <File Id="InvalidJsonFile" Name="invalid.json" Source="invalid.json" KeyPath="yes" />
+        <Json:JsonFile Id="modifyInvalidJson"
+               File="[#InvalidJsonFile]"
+               ElementPath="$.Data.Value"
+               Value="ShouldNeverBeWritten"
+               Action="setValue"
+               Sequence="1" />
+      </Component>
+
+      <!-- Sad path: schema validation failure. Only installed when TEST_SCHEMA_FAILURE=1 is passed.
+           schema-invalid.json is valid JSON (so the setValue succeeds) but is missing the required
+           "store" property, so validation against appsettings-schema.json fails and aborts the install. -->
+      <Component Id="SchemaFailureComponent" Guid="{069E7A31-B0F2-4187-A313-CBE659D385A5}" Condition="TEST_SCHEMA_FAILURE=1">
+        <File Id="SchemaInvalidFile" Name="schema-invalid.json" Source="schema-invalid.json" KeyPath="yes" />
+        <Json:JsonFile Id="validateSchemaFailure"
+               File="[#SchemaInvalidFile]"
+               ElementPath="$.notStore.value"
+               Value="2"
+               Action="setValue"
+               SchemaFile="[#AppSettingsSchema]"
+               Sequence="1" />
       </Component>
     </ComponentGroup>
   </Fragment>

--- a/TestJsonConfigInstaller/Product.wxs
+++ b/TestJsonConfigInstaller/Product.wxs
@@ -24,6 +24,12 @@
     <Property Id="REG_READ_PRESENT" Value="PROPERTY_NOT_SET" />
     <Property Id="REG_READ_MISSING" Value="PROPERTY_NOT_SET" />
 
+    <!-- Switches for the property-gated sad-path components. Declared (default 0) so component
+         conditions reference known properties (silences ICE28); set to 1 on the msiexec command
+         line to enable the corresponding failure scenario. -->
+    <Property Id="TEST_INVALID_JSON" Value="0" />
+    <Property Id="TEST_SCHEMA_FAILURE" Value="0" />
+
     <Feature Id="ProductFeature" Title="TestJsonConfigInstaller" Level="1">
       <ComponentGroupRef Id="ProductComponents" />
     </Feature>
@@ -264,7 +270,9 @@
 
       <!-- Installs the JSON schema used for validateSchema coverage. Kept in its own component so
            it can be referenced (via [#AppSettingsSchema]) by both the happy-path validation in
-           ProductComponent and the schema-failure regression component below. -->
+           ProductComponent and the schema-failure regression component below. Must remain
+           unconditional: if it were ever gated, those [#AppSettingsSchema] references would resolve
+           to an empty path at runtime. -->
       <Component Id="SchemaFileComponent" Guid="{58862E01-A058-4CB1-9FA3-66D81F5F6639}">
         <File Id="AppSettingsSchema" Name="appsettings-schema.json" Source="appsettings-schema.json" KeyPath="yes" />
       </Component>

--- a/TestJsonConfigInstaller/Product.wxs
+++ b/TestJsonConfigInstaller/Product.wxs
@@ -136,7 +136,32 @@
                Action="setValue"
                OnlyIfExists="yes"
                Sequence="14"/>
-        
+
+        <!-- Array operation variations on an isolated array ($.arrayOps starts as ["seed"]).
+             Exercises insertArray at the front (Index=0), insertArray append (Index=-1) and
+             appendArray, so the distinct index code paths are verified. Final order must be
+             ["first", "seed", "last", "appended"]. -->
+        <Json:JsonFile Id="arrayInsertFront"
+               File="[#JsonConfig]"
+               ElementPath="$.arrayOps"
+               Value="first"
+               Action="insertArray"
+               Index="0"
+               Sequence="20"/>
+        <Json:JsonFile Id="arrayInsertEnd"
+               File="[#JsonConfig]"
+               ElementPath="$.arrayOps"
+               Value="last"
+               Action="insertArray"
+               Index="-1"
+               Sequence="21"/>
+        <Json:JsonFile Id="arrayAppend"
+               File="[#JsonConfig]"
+               ElementPath="$.arrayOps"
+               Value="appended"
+               Action="appendArray"
+               Sequence="22"/>
+
       </Component>
 
       <!-- New: Template-based configuration -->
@@ -195,13 +220,32 @@
           Action="createJsonPointerValue" 
           Sequence="3" />
           
-        <Json:JsonFile 
-          Id="CreateLogLevel" 
-          File="[#EmptyConfig]" 
+        <Json:JsonFile
+          Id="CreateLogLevel"
+          File="[#EmptyConfig]"
           ElementPath="/Logging/Level"
           Value="Debug"
           Action="createJsonPointerValue"
           Sequence="4" />
+
+        <!-- Write the values produced by the readValue operations (REG_READ_PRESENT /
+             REG_READ_MISSING) into this installed file so the regression test can verify
+             readValue end-to-end by inspecting file content rather than MSI log wording. -->
+        <Json:JsonFile
+          Id="WriteReadPresent"
+          File="[#EmptyConfig]"
+          ElementPath="/ReadResults/Present"
+          Value="[REG_READ_PRESENT]"
+          Action="createJsonPointerValue"
+          Sequence="5" />
+
+        <Json:JsonFile
+          Id="WriteReadMissing"
+          File="[#EmptyConfig]"
+          ElementPath="/ReadResults/Missing"
+          Value="[REG_READ_MISSING]"
+          Action="createJsonPointerValue"
+          Sequence="6" />
       </Component>
 
       <!-- Installs the JSON schema used for validateSchema coverage. Kept in its own component so

--- a/TestJsonConfigInstaller/appsettings.json
+++ b/TestJsonConfigInstaller/appsettings.json
@@ -90,5 +90,6 @@
 	"tags": ["production", "webapp", "production", "backend", "webapp", "api"],
 	"features": {
 		"enabled": ["feature1", "feature2", "feature1", "feature3"]
-	}
+	},
+	"arrayOps": ["seed"]
 }

--- a/TestJsonConfigInstaller/schema-invalid.json
+++ b/TestJsonConfigInstaller/schema-invalid.json
@@ -1,0 +1,6 @@
+{
+  "_comment": "Valid JSON, but intentionally violates appsettings-schema.json (missing the required 'store' property) so schema validation fails.",
+  "notStore": {
+    "value": 1
+  }
+}


### PR DESCRIPTION
The previous regression workflow mostly re-implemented JSON semantics in
PowerShell, which validated PowerShell's parser rather than the extension.
Replace those checks with real end-to-end tests that install the MSI and
assert the extension's actual output for every flag type, covering happy
and sad paths:

- readValue (happy + missing element falls back to DefaultValue)
- setValue (filter, nested, recursive-descent multi-select, OnlyIfExists)
- replaceJsonValue, createJsonPointerValue, deleteValue
- appendArray, insertArray, removeArrayElement, distinctValues
- validateSchema (passes for valid file; violation aborts install)
- OnlyIfExists (updates existing, skips missing)
- non-ASCII (UTF-8) value preservation
- invalid JSON aborts and rolls back the install

Add a dedicated readValue source, a schema File, and two property-gated
sad-path components (TEST_INVALID_JSON, TEST_SCHEMA_FAILURE) to Product.wxs
so failure paths can be exercised without affecting a normal install, and
document the coverage matrix in TESTING.md.

https://claude.ai/code/session_01GsaYrH9mJAxvFJyjV7Z9D3