### PR TITLE
Auto-generate release notes from merged PRs in Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,9 +60,10 @@ jobs:
       with:
         tag_name: ${{ github.event_name == 'workflow_dispatch' && format('v{0}', inputs.version) || github.ref_name }}
         name: Release ${{ steps.version.outputs.version }}
+        # Auto-generate a "What's Changed" changelog from merged PRs since the
+        # previous tag. The install snippet below is prepended to those notes.
+        generate_release_notes: true
         body: |
-          Release version ${{ steps.version.outputs.version }}
-          
           ## Installation
           ```
           dotnet add package WixJsonFileExtension --version ${{ steps.version.outputs.version }}


### PR DESCRIPTION
## Summary

The Release workflow hard-coded a generic body, so every GitHub release read `Release version X` with just an install snippet and no changelog (e.g. v6.4.0).

This enables `generate_release_notes: true` on `softprops/action-gh-release`, so future releases automatically get a **What's Changed** section built from the PRs merged since the previous tag. The install snippet is kept and prepended to those notes.

## Changes
- `.github/workflows/release.yml`: add `generate_release_notes: true`; drop the redundant `Release version X` line from the hard-coded body.

## Notes
- This only affects releases cut **after** this merges. The existing v6.4.0 release body still needs a one-time manual update.

https://claude.ai/code/session_019TKqAhj78P8kaLRta6HrLc

---
_Generated by [Claude Code](https://claude.ai/code/session_019TKqAhj78P8kaLRta6HrLc)_