### PR TITLE
Fix review findings: CreateIfMissing, value typing, atomic writes, OnlyIfExists

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -47,6 +47,14 @@ jobs:
       run: nuget restore ${{ env.SOLUTION_FILE_PATH }}
 
     # Single build of the solution. The unit tests below reuse its output: the wixext embeds the
+    # Build the custom action DLL for the non-x64 platforms first: the wixlib compiles its
+    # x86/ARM64 fragments (and embeds those DLLs) only when the outputs exist.
+    - name: Build x86 and ARM64 custom action DLLs
+      run: |
+        msbuild /m /p:Configuration=${{ env.BUILD_CONFIGURATION }} /p:Platform=Win32 /p:SolutionDir=${{ github.workspace }}\ src\ca\jsonca.vcxproj
+        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+        msbuild /m /p:Configuration=${{ env.BUILD_CONFIGURATION }} /p:Platform=ARM64 /p:SolutionDir=${{ github.workspace }}\ src\ca\jsonca.vcxproj
+
     # wixlib produced here, and the C++ test project links the WiX native packages restored above.
     - name: Build
       run: msbuild /m /p:Configuration=${{ env.BUILD_CONFIGURATION }} ${{ env.SOLUTION_FILE_PATH }}

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -51,6 +51,8 @@ jobs:
     # x86/ARM64 fragments (and embeds those DLLs) only when the outputs exist.
     - name: Build x86 and ARM64 custom action DLLs
       run: |
+        # Diagnostic: list the platform toolsets available on this runner image.
+        Get-ChildItem "C:\Program Files\Microsoft Visual Studio\*\*\MSBuild\Microsoft\VC\*\Platforms\*\PlatformToolsets\*" -Directory -ErrorAction SilentlyContinue | Select-Object -ExpandProperty FullName
         msbuild /m /p:Configuration=${{ env.BUILD_CONFIGURATION }} /p:Platform=Win32 /p:SolutionDir=${{ github.workspace }}\ src\ca\jsonca.vcxproj
         if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
         msbuild /m /p:Configuration=${{ env.BUILD_CONFIGURATION }} /p:Platform=ARM64 /p:SolutionDir=${{ github.workspace }}\ src\ca\jsonca.vcxproj

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -56,6 +56,7 @@ jobs:
         msbuild /m /p:Configuration=${{ env.BUILD_CONFIGURATION }} /p:Platform=Win32 /p:SolutionDir=${{ github.workspace }}\ src\ca\jsonca.vcxproj
         if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
         msbuild /m /p:Configuration=${{ env.BUILD_CONFIGURATION }} /p:Platform=ARM64 /p:SolutionDir=${{ github.workspace }}\ src\ca\jsonca.vcxproj
+        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
     # wixlib produced here, and the C++ test project links the WiX native packages restored above.
     - name: Build

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -39,6 +39,7 @@ jobs:
         msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} /p:Platform=Win32 /p:SolutionDir=${{ github.workspace }}\ src\ca\jsonca.vcxproj
         if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
         msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} /p:Platform=ARM64 /p:SolutionDir=${{ github.workspace }}\ src\ca\jsonca.vcxproj
+        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
     - name: Build Solution
       working-directory: ${{env.GITHUB_WORKSPACE}}

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -30,6 +30,16 @@ jobs:
       working-directory: ${{env.GITHUB_WORKSPACE}}
       run: nuget restore ${{env.SOLUTION_FILE_PATH}}
 
+    # Build the custom action DLL for the non-x64 platforms first: the wixlib compiles its
+    # x86/ARM64 fragments (and embeds those DLLs) only when the outputs exist, and the test
+    # installer should exercise the same multi-platform wixlib that gets released.
+    - name: Build x86 and ARM64 custom action DLLs
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: |
+        msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} /p:Platform=Win32 /p:SolutionDir=${{ github.workspace }}\ src\ca\jsonca.vcxproj
+        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+        msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} /p:Platform=ARM64 /p:SolutionDir=${{ github.workspace }}\ src\ca\jsonca.vcxproj
+
     - name: Build Solution
       working-directory: ${{env.GITHUB_WORKSPACE}}
       run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,16 @@ jobs:
       working-directory: ${{env.GITHUB_WORKSPACE}}
       run: nuget restore ${{env.SOLUTION_FILE_PATH}}
 
+    # Build the custom action DLL for the non-x64 platforms first: the wixlib compiles its
+    # x86/ARM64 fragments (and embeds those DLLs) only when the outputs exist, so released
+    # packages must carry all three platforms.
+    - name: Build x86 and ARM64 custom action DLLs
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: |
+        msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} /p:Platform=Win32 /p:SolutionDir=${{ github.workspace }}\ src\ca\jsonca.vcxproj
+        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+        msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} /p:Platform=ARM64 /p:SolutionDir=${{ github.workspace }}\ src\ca\jsonca.vcxproj
+
     - name: Build
       working-directory: ${{env.GITHUB_WORKSPACE}}
       run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,7 @@ jobs:
         msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} /p:Platform=Win32 /p:SolutionDir=${{ github.workspace }}\ src\ca\jsonca.vcxproj
         if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
         msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} /p:Platform=ARM64 /p:SolutionDir=${{ github.workspace }}\ src\ca\jsonca.vcxproj
+        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
     - name: Build
       working-directory: ${{env.GITHUB_WORKSPACE}}

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Simplified syntax for .NET application settings:
 **Attributes:**
 - `Key` - Dot-notation path (automatically converted to JSONPath)
 - `Value` - The value to set
-- `CreateIfMissing` - (Optional) Create nested path if it doesn't exist (default: yes)
+- `CreateIfMissing` - (Optional) Create nested path if it doesn't exist (default: yes). When `yes`, the setting is written with the `createJsonPointerValue` action so missing keys (including intermediate objects) are created. When `no`, the setting is only updated if the key already exists; missing keys are skipped without failing the install
 
 #### Json:ConnectionString
 
@@ -415,7 +415,7 @@ The `JsonFile` element supports the following actions:
 | `setValue` | Sets or updates a value at the specified path (default action if not specified) | JSONPath | Updating existing JSON properties |
 | `deleteValue` | Deletes the value(s) at the specified path | JSONPath | Removing configuration entries |
 | `replaceJsonValue` | Replaces an entire JSON object or array with new JSON content | JSONPath | Replacing complex nested structures |
-| `createJsonPointerValue` | Creates a new value using JSONPointer syntax (useful for creating nested paths that don't exist) | JSONPointer | Creating new configuration sections |
+| `createJsonPointerValue` | Sets a value using JSONPointer syntax, creating the path (including intermediate objects) if it doesn't exist. Existing values at the path are overwritten | JSONPointer | Creating new configuration sections |
 | `appendArray` | Appends a value to an array | JSONPath | Adding new items to configuration arrays |
 | `insertArray` | Inserts a value at a specific index in an array | JSONPath | Adding items at specific positions in arrays |
 | `removeArrayElement` | Removes element(s) from an array by value or path | JSONPath | Removing specific items from configuration arrays |
@@ -429,13 +429,26 @@ The `JsonFile` element supports the following actions:
 | `File` | Yes | Path to the JSON file to modify. Can use file references like `[#FileId]` or formatted paths like `[INSTALLFOLDER]config.json` |
 | `ElementPath` | Yes | JSONPath or JSONPointer expression to locate the element(s) to modify |
 | `Action` | No | The action to perform (see Available Actions table). Defaults to `setValue` |
-| `Value` | Conditional | The value to set. Required for `setValue`, `replaceJsonValue`, `createJsonPointerValue`, `appendArray`, and `insertArray` actions. For `removeArrayElement`, `Value` is optional: if omitted, elements matched by the JSONPath expression are removed; if provided, all array elements matching that value are removed. Can be a simple value, property reference like `[PROPERTY_NAME]`, or JSON-formatted string |
-| `DefaultValue` | No | Default value to use if the path doesn't exist (used with `readValue`) |
+| `Value` | Conditional | The value to set. Required for `setValue`, `replaceJsonValue`, `createJsonPointerValue`, `appendArray`, and `insertArray` actions. For `removeArrayElement`, `Value` is optional: if omitted, elements matched by the JSONPath expression are removed; if provided, all array elements matching that value are removed. Can be a simple value, property reference like `[PROPERTY_NAME]`, or JSON-formatted string. See "Value typing" below for how values are converted to JSON types |
+| `DefaultValue` | No | Default value to use if the value cannot be read - the path doesn't exist, the file doesn't exist, or the file cannot be parsed (used with `readValue`) |
 | `Property` | Conditional | Windows Installer property to store the read value. Required for `readValue` action |
-| `Sequence` | No | Order in which modifications are applied (default: 1). Lower numbers execute first. Use this to ensure JSON changes happen before services start or in a specific order. All JSON modifications run after `InstallFiles` and before `StartServices` in the standard InstallExecuteSequence |
+| `Sequence` | No | Order in which modifications are applied. Lower numbers execute first. When omitted, elements are automatically assigned increasing sequence numbers in authoring order, so operations on the same file execute deterministically in the order they appear in your source. Use this to ensure JSON changes happen before services start or in a specific order. All JSON modifications run after `InstallFiles` and before `StartServices` in the standard InstallExecuteSequence |
 | `Index` | No | For `insertArray` action: specifies the index at which to insert. Use -1 or omit to append to end |
 | `SchemaFile` | No | Path to a JSON schema file for validation. The JSON file will be validated against this schema after modifications |
-| `OnlyIfExists` | No | When set to `yes`, the action is only performed if the ElementPath already exists in the JSON file. This is useful for conditional updates that should only modify existing values without creating new ones. Applies to `setValue`, `createJsonPointerValue`, and `replaceJsonValue` actions. Default is `no` |
+| `OnlyIfExists` | No | When set to `yes`, the action is only performed if the ElementPath already exists in the JSON file. If the path (or the file itself) does not exist, the operation is skipped and the install continues. This is useful for conditional updates that should only modify existing values without creating new ones. Applies to all write actions. Default is `no` |
+
+### Value Typing
+
+How the `Value` attribute is converted into a JSON value:
+
+- **Replacing an existing string value** (`setValue`, `createJsonPointerValue`): the new value is always written as a string, so values like `"1.0"` or `"true"` don't silently change type.
+- **Replacing a non-string value or creating a new value**: the value is parsed as JSON first, so `9090` becomes a number, `true`/`false` become booleans, and `["a","b"]` becomes an array. If the value is not valid JSON it is written as a string.
+- **`appendArray` / `insertArray` / `removeArrayElement`**: the value is parsed as JSON with a fallback to string (unchanged behavior).
+- **`replaceJsonValue`**: the value must be valid JSON and is written exactly as parsed (unchanged behavior).
+
+### File Writes
+
+All modifications are written atomically: the updated JSON is written to a temporary file next to the target and then swapped in, so a failure mid-write can never leave a truncated or corrupted configuration file. Note that files are re-serialized (pretty-printed) on every write, so original formatting and any non-standard content such as comments are not preserved (files containing comments fail to parse).
 
 ### JSONPath vs JSONPointer
 
@@ -932,6 +945,7 @@ The `OnlyIfExists` attribute allows you to conditionally update JSON values only
 **Behavior:**
 - If `OnlyIfExists="yes"` and the path exists: the operation proceeds normally
 - If `OnlyIfExists="yes"` and the path does NOT exist: the operation is skipped (returns success, no error)
+- If `OnlyIfExists="yes"` and the JSON file itself does NOT exist: the operation is skipped (returns success, no error)
 - If `OnlyIfExists="no"` (or omitted): the operation always proceeds (default behavior)
 
 ### JSON Schema Validation

--- a/README.md
+++ b/README.md
@@ -106,6 +106,18 @@ This extension works with all .NET application types that use JSON configuration
 
 **Hybrid scenarios**: Applications using both classic `.config` (XML) and modern JSON files can leverage both WiX's built-in XML handling and this extension for JSON files.
 
+### Installer Platform Support
+
+The custom action DLL ships for all Windows Installer platforms, and the extension automatically references the variant matching your package's platform:
+
+| MSI Platform | Support Status |
+|--------------|----------------|
+| **x64** | ✅ Supported |
+| **x86** | ✅ Supported |
+| **ARM64** | ✅ Supported |
+
+Note: when building the extension from source, a plain x64 solution build produces an x64-only wixlib; build `src/ca/jsonca.vcxproj` for `Win32` and `ARM64` first (as CI does) to produce the multi-platform wixlib.
+
 ## Prerequisites
 
 - **WiX Toolset**: Version 4.x or later (for WiX v5/v6 support)

--- a/src/ca/AppendJsonArray.cpp
+++ b/src/ca/AppendJsonArray.cpp
@@ -81,23 +81,10 @@ HRESULT AppendJsonArray(__in_z LPCWSTR wzFile, const std::string& sElementPath, 
 
             WcaLog(LOGMSG_STANDARD, "Successfully appended value to array");
 
-            // Serialize before truncating so a serialization failure cannot leave the file empty.
-            std::ostringstream serialized;
-            serialized << pretty_print(j);
-
-            std::ofstream os(wzFile, std::ios_base::out | std::ios_base::trunc);
-            if (!os.is_open())
+            hr = WriteJsonOutput(wzFile, j);
+            if (FAILED(hr))
             {
-                WcaLog(LOGMSG_STANDARD, "Failed to open output file stream: %ls", wzFile);
-                return HRESULT_FROM_WIN32(ERROR_OPEN_FAILED);
-            }
-
-            os << serialized.str();
-            os.close();
-            if (os.fail())
-            {
-                WcaLog(LOGMSG_STANDARD, "Failed to write output file: %ls", wzFile);
-                return HRESULT_FROM_WIN32(ERROR_WRITE_FAULT);
+                return hr;
             }
         }
         else {

--- a/src/ca/DeleteJsonPath.cpp
+++ b/src/ca/DeleteJsonPath.cpp
@@ -55,25 +55,10 @@ HRESULT DeleteJsonPath(__in_z LPCWSTR wzFile, const std::string& sElementPath)
                        locations.size(), sElementPath.c_str(), wzFile);
             }
 
-            // Serialize before truncating so a serialization failure cannot leave the file empty.
-            std::ostringstream serialized;
-            serialized << pretty_print(j);
-
-            SetLastError(0);
-            std::ofstream os(wzFile, std::ios_base::out | std::ios_base::trunc);
-            if (!os.is_open())
+            hr = WriteJsonOutput(wzFile, j);
+            if (FAILED(hr))
             {
-                WcaLog(LOGMSG_STANDARD, "WixJsonFile: Error - Failed to create output stream for file '%ls'", wzFile);
-                hr = ReturnLastError("creating the output stream");
-                return FAILED(hr) ? hr : HRESULT_FROM_WIN32(ERROR_OPEN_FAILED);
-            }
-
-            os << serialized.str();
-            os.close();
-            if (os.fail())
-            {
-                WcaLog(LOGMSG_STANDARD, "WixJsonFile: Error - Failed to write file '%ls'", wzFile);
-                return HRESULT_FROM_WIN32(ERROR_WRITE_FAULT);
+                return hr;
             }
         }
         else {

--- a/src/ca/DistinctJsonArray.cpp
+++ b/src/ca/DistinctJsonArray.cpp
@@ -106,16 +106,11 @@ HRESULT DistinctJsonArray(__in_z LPCWSTR wzFile, const std::string& sElementPath
 
             WcaLog(LOGMSG_STANDARD, "Successfully removed duplicates from array");
 
-            std::ofstream os(wzFile, std::ios_base::out | std::ios_base::trunc);
-
-            if (!os.is_open())
+            HRESULT hr = WriteJsonOutput(wzFile, j);
+            if (FAILED(hr))
             {
-                WcaLog(LOGMSG_STANDARD, "Failed to open output file stream: %ls", wzFile);
-                return HRESULT_FROM_WIN32(ERROR_OPEN_FAILED);
+                return hr;
             }
-
-            pretty_print(j).dump(os);
-            os.close();
         }
         else {
             WcaLog(LOGMSG_STANDARD, "Unable to locate file: %ls", wzFile);

--- a/src/ca/Errors.cpp
+++ b/src/ca/Errors.cpp
@@ -16,6 +16,12 @@ std::string GetLastErrorAsString()
     size_t size = FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
         NULL, errorMessageID, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR)&messageBuffer, 0, NULL);
 
+    // FormatMessage can fail (returning 0 with no buffer); fall back to the numeric code.
+    if (0 == size || nullptr == messageBuffer)
+    {
+        return "error code " + std::to_string(errorMessageID);
+    }
+
     //Copy the error message into a std::string.
     std::string message(messageBuffer, size);
 

--- a/src/ca/ExecJsonFile.cpp
+++ b/src/ca/ExecJsonFile.cpp
@@ -72,12 +72,6 @@ extern "C" UINT WINAPI ExecJsonFile(
         ExitOnFailure(hr, "WixJsonFile: Failed while updating file '%ls' at path '%ls'", sczFile, sczElementPath)
     }
 
-    // reaching the end of the list is actually a good thing, not an error
-    if (E_NOMOREITEMS == hr)
-    {
-        hr = S_OK;
-    }
-
 LExit:
     ReleaseStr(pwzCustomActionData)
     ReleaseStr(sczFile)

--- a/src/ca/ExecJsonFileRollback.cpp
+++ b/src/ca/ExecJsonFileRollback.cpp
@@ -51,8 +51,9 @@ extern "C" UINT WINAPI ExecJsonFileRollback(
             WcaLog(LOGMSG_STANDARD, "Warning: failed to get modified date of file %ls; rollback will not preserve its timestamp", pwzFileName);
         }
 
-        // Open the file
-        hFile = ::CreateFileW(pwzFileName, GENERIC_WRITE, FILE_SHARE_READ, NULL, TRUNCATE_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+        // Open the file. CREATE_ALWAYS (rather than TRUNCATE_EXISTING) so the captured contents
+        // are restored even if the file was deleted between scheduling and rollback.
+        hFile = ::CreateFileW(pwzFileName, GENERIC_WRITE, FILE_SHARE_READ, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
         ExitOnInvalidHandleWithLastError(hFile, hr, "failed to open file for rollback: %ls", pwzFileName);
 
         // Write out the old data

--- a/src/ca/InsertJsonArray.cpp
+++ b/src/ca/InsertJsonArray.cpp
@@ -97,23 +97,10 @@ HRESULT InsertJsonArray(__in_z LPCWSTR wzFile, const std::string& sElementPath, 
 
             WcaLog(LOGMSG_STANDARD, "Successfully inserted value into array");
 
-            // Serialize before truncating so a serialization failure cannot leave the file empty.
-            std::ostringstream serialized;
-            serialized << pretty_print(j);
-
-            std::ofstream os(wzFile, std::ios_base::out | std::ios_base::trunc);
-            if (!os.is_open())
+            hr = WriteJsonOutput(wzFile, j);
+            if (FAILED(hr))
             {
-                WcaLog(LOGMSG_STANDARD, "Failed to open output file stream for writing: %ls", wzFile);
-                return HRESULT_FROM_WIN32(ERROR_OPEN_FAILED);
-            }
-
-            os << serialized.str();
-            os.close();
-            if (os.fail())
-            {
-                WcaLog(LOGMSG_STANDARD, "Failed to write output file: %ls", wzFile);
-                return HRESULT_FROM_WIN32(ERROR_WRITE_FAULT);
+                return hr;
             }
         }
         else {

--- a/src/ca/JsonFile.h
+++ b/src/ca/JsonFile.h
@@ -1,7 +1,6 @@
 #pragma once
 #include "stdafx.h"
 
-#include <atlbase.h>
 #include <vector>
 
 using namespace jsoncons;

--- a/src/ca/JsonFile.h
+++ b/src/ca/JsonFile.h
@@ -124,6 +124,11 @@ HRESULT ValidateJsonSchema(__in_z LPCWSTR wzFile, __in_z LPCWSTR wzSchemaFile);
 std::string GetLastErrorAsString();
 HRESULT ReturnLastError(const std::string& action);
 
+// Atomically serializes and writes a JSON document to a file (temp file + replace).
+HRESULT WriteJsonOutput(__in_z LPCWSTR wzFile, const json& j);
+// Converts an authored value to a typed JSON value; preserves string type when replacing a string.
+json MakeJsonValue(const std::string& valueUtf8, const json* pExisting);
+
 inline HRESULT WideToUtf8(__in_z LPCWSTR wzInput, std::string& value)
 {
     value.clear();

--- a/src/ca/JsonWrite.cpp
+++ b/src/ca/JsonWrite.cpp
@@ -1,0 +1,102 @@
+#include "stdafx.h"
+#include "JsonFile.h"
+
+// Serializes the document and atomically replaces the target file: the JSON is written to a
+// temporary file in the same directory, flushed, then swapped in with ReplaceFileW (which
+// preserves the original file's attributes and ACLs). The original file is never truncated
+// before the new content is safely on disk, so a serialization or write failure - or a crash
+// mid-write - cannot corrupt the target.
+HRESULT WriteJsonOutput(__in_z LPCWSTR wzFile, const json& j)
+{
+    try
+    {
+        if (NULL == wzFile || L'\0' == *wzFile)
+        {
+            return E_INVALIDARG;
+        }
+
+        std::ostringstream serialized;
+        serialized << pretty_print(j);
+        if (serialized.fail())
+        {
+            WcaLog(LOGMSG_STANDARD, "WixJsonFile: Error - Failed to serialize JSON for file '%ls'", wzFile);
+            return HRESULT_FROM_WIN32(ERROR_WRITE_FAULT);
+        }
+
+        fs::path targetPath(wzFile);
+        fs::path tempPath = targetPath;
+        tempPath += L".wixjson.tmp";
+
+        {
+            // Text mode (like the previous in-place writes) so line endings stay CRLF on Windows.
+            std::ofstream os(tempPath, std::ios_base::out | std::ios_base::trunc);
+            if (!os.is_open())
+            {
+                WcaLog(LOGMSG_STANDARD, "WixJsonFile: Error - Failed to create temporary file for '%ls'", wzFile);
+                return HRESULT_FROM_WIN32(ERROR_OPEN_FAILED);
+            }
+
+            os << serialized.str();
+            os.close();
+            if (os.fail())
+            {
+                WcaLog(LOGMSG_STANDARD, "WixJsonFile: Error - Failed to write temporary file for '%ls'", wzFile);
+                std::error_code ec;
+                fs::remove(tempPath, ec);
+                return HRESULT_FROM_WIN32(ERROR_WRITE_FAULT);
+            }
+        }
+
+        if (!::ReplaceFileW(targetPath.c_str(), tempPath.c_str(), NULL,
+                            REPLACEFILE_IGNORE_MERGE_ERRORS | REPLACEFILE_IGNORE_ACL_ERRORS, NULL, NULL))
+        {
+            DWORD dwError = ::GetLastError();
+
+            // ReplaceFileW requires the target to exist; fall back to a move when it does not
+            // (or when the volume rejects the replace for another transient reason).
+            if (!::MoveFileExW(tempPath.c_str(), targetPath.c_str(),
+                               MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH))
+            {
+                DWORD dwMoveError = ::GetLastError();
+                WcaLog(LOGMSG_STANDARD, "WixJsonFile: Error - Failed to replace file '%ls' (replace error=%u, move error=%u)",
+                       wzFile, dwError, dwMoveError);
+                std::error_code ec;
+                fs::remove(tempPath, ec);
+                return HRESULT_FROM_WIN32(dwMoveError ? dwMoveError : ERROR_WRITE_FAULT);
+            }
+        }
+
+        return S_OK;
+    }
+    catch (const std::exception& e)
+    {
+        WcaLog(LOGMSG_STANDARD, "WixJsonFile: Error - Exception while writing file '%ls': %s", wzFile, e.what());
+        return E_FAIL;
+    }
+    catch (...)
+    {
+        WcaLog(LOGMSG_STANDARD, "WixJsonFile: Error - Unknown error while writing file '%ls'", wzFile);
+        return E_FAIL;
+    }
+}
+
+// Parses an authored attribute value into a JSON value. Values that parse as JSON (numbers,
+// booleans, null, objects, arrays, quoted strings) become that typed value; anything else is
+// treated as a plain string. When the value replaces an existing string, the string type is
+// preserved so values like "1.0" stay strings instead of silently becoming numbers.
+json MakeJsonValue(const std::string& valueUtf8, const json* pExisting)
+{
+    if (pExisting != NULL && pExisting->is_string())
+    {
+        return json(valueUtf8);
+    }
+
+    try
+    {
+        return json::parse(valueUtf8);
+    }
+    catch (const std::exception&)
+    {
+        return json(valueUtf8);
+    }
+}

--- a/src/ca/JsonWrite.cpp
+++ b/src/ca/JsonWrite.cpp
@@ -1,6 +1,12 @@
 #include "stdafx.h"
 #include "JsonFile.h"
 
+// Not defined when _WIN32_WINNT targets pre-Vista (see targetver.h); the flag is simply
+// ignored by ReplaceFileW on systems that do not support it.
+#ifndef REPLACEFILE_IGNORE_ACL_ERRORS
+#define REPLACEFILE_IGNORE_ACL_ERRORS 0x00000004
+#endif
+
 // Serializes the document and atomically replaces the target file: the JSON is written to a
 // temporary file in the same directory, flushed, then swapped in with ReplaceFileW (which
 // preserves the original file's attributes and ACLs). The original file is never truncated

--- a/src/ca/ReadJsonFileTable.cpp
+++ b/src/ca/ReadJsonFileTable.cpp
@@ -126,11 +126,12 @@ HRESULT ReadJsonFileTable(
         hr = StrAllocString(&(*ppxfcTail)->pwzProperty, pwzData, 0);
         ExitOnFailure(hr, "failed to allocate buffer for property")
 
-        // Get the index
+        // Get the index. WcaGetRecordInteger returns S_FALSE (not a failure) and leaves
+        // MSI_NULL_INTEGER in the output when the column is null, so check both.
         hr = WcaGetRecordInteger(hRec, jfqIndex, &(*ppxfcTail)->iIndex);
-        if (FAILED(hr))
+        if (FAILED(hr) || S_FALSE == hr || MSI_NULL_INTEGER == (*ppxfcTail)->iIndex)
         {
-            // Index is optional, default to -1
+            // Index is optional, default to -1 (append to end)
             (*ppxfcTail)->iIndex = -1;
             hr = S_OK;
         }

--- a/src/ca/ReadValueJsonFile.cpp
+++ b/src/ca/ReadValueJsonFile.cpp
@@ -116,7 +116,11 @@ extern "C" UINT WINAPI ReadValueJsonFile(
                 }
                 else
                 {
-                    WcaLog(LOGMSG_STANDARD, "File %ls not found", pxfc->wzFile);
+                    // A missing file means the value cannot be located, so the property gets
+                    // the default - consistent with parse failures and missing paths.
+                    WcaLog(LOGMSG_STANDARD, "File %ls not found, setting property %ls to default value",
+                        pxfc->wzFile, pxfc->pwzProperty);
+                    WcaSetProperty(pxfc->pwzProperty, pxfc->pwzDefaultValue);
                 }
 
                 ++cFiles;
@@ -124,12 +128,7 @@ extern "C" UINT WINAPI ReadValueJsonFile(
         }
     }
 
-    WcaLog(LOGMSG_STANDARD, "Built File list!");
-
-    // If we looped through all records all is well
-    if (E_NOMOREITEMS == hr)
-        hr = S_OK;
-    ExitOnFailure(hr, "failed while looping through all objects to secure")
+    WcaLog(LOGMSG_VERBOSE, "Processed %d readValue entries", cFiles);
 
 LExit:
     // Free the linked list to prevent memory leak

--- a/src/ca/RemoveJsonArrayElement.cpp
+++ b/src/ca/RemoveJsonArrayElement.cpp
@@ -103,16 +103,11 @@ HRESULT RemoveJsonArrayElement(__in_z LPCWSTR wzFile, const std::string& sElemen
 
             WcaLog(LOGMSG_STANDARD, "Successfully removed elements from array");
 
-            std::ofstream os(wzFile, std::ios_base::out | std::ios_base::trunc);
-
-            if (!os.is_open())
+            hr = WriteJsonOutput(wzFile, j);
+            if (FAILED(hr))
             {
-                WcaLog(LOGMSG_STANDARD, "Failed to open output file stream for writing: %ls", wzFile);
-                return HRESULT_FROM_WIN32(ERROR_OPEN_FAILED);
+                return hr;
             }
-
-            pretty_print(j).dump(os);
-            os.close();
         }
         else {
             WcaLog(LOGMSG_STANDARD, "Unable to locate file: %ls", wzFile);

--- a/src/ca/SchedJsonFile.cpp
+++ b/src/ca/SchedJsonFile.cpp
@@ -114,7 +114,6 @@ extern "C" UINT __stdcall SchedJsonFile(
             }
 
             hr = WcaWriteStringToCaData(pxfc->wzFile, &pwzCustomActionData);
-            WcaLog(LOGMSG_STANDARD, "WixJsonFile: Scheduling operation for file: %ls", pxfc->wzFile);
             ExitOnFailure(hr, "failed to write file to custom action data: %ls", pxfc->wzFile)
 
             hr = WcaWriteStringToCaData(pxfc->pwzElementPath, &pwzCustomActionData);
@@ -138,11 +137,6 @@ extern "C" UINT __stdcall SchedJsonFile(
     }
 
     WcaLog(LOGMSG_VERBOSE, "Scheduled %d file operations", cFiles);
-
-    // If we looped through all records all is well
-    if (E_NOMOREITEMS == hr)
-        hr = S_OK;
-    ExitOnFailure(hr, "failed while looping through all objects to secure")
 
     // Schedule the rollback custom action first
     if (fScheduledRollback && pwzRollbackCustomActionData && *pwzRollbackCustomActionData)

--- a/src/ca/SetJsonPathObject.cpp
+++ b/src/ca/SetJsonPathObject.cpp
@@ -83,25 +83,10 @@ HRESULT SetJsonPathObject(__in_z LPCWSTR wzFile, const std::string& sElementPath
             WcaLog(LOGMSG_STANDARD, "WixJsonFile: Successfully replaced JSON object at path '%s' in file '%ls'", 
                    sElementPath.c_str(), wzFile);
 
-            // Serialize before truncating so a serialization failure cannot leave the file empty.
-            std::ostringstream serialized;
-            serialized << pretty_print(j);
-
-            SetLastError(0);
-            std::ofstream os(wzFile, std::ios_base::out | std::ios_base::trunc);
-            if (!os.is_open())
+            hr = WriteJsonOutput(wzFile, j);
+            if (FAILED(hr))
             {
-                WcaLog(LOGMSG_STANDARD, "WixJsonFile: Error - Failed to create output stream for file '%ls'", wzFile);
-                hr = ReturnLastError("creating the output stream");
-                return FAILED(hr) ? hr : HRESULT_FROM_WIN32(ERROR_OPEN_FAILED);
-            }
-
-            os << serialized.str();
-            os.close();
-            if (os.fail())
-            {
-                WcaLog(LOGMSG_STANDARD, "WixJsonFile: Error - Failed to write file '%ls'", wzFile);
-                return HRESULT_FROM_WIN32(ERROR_WRITE_FAULT);
+                return hr;
             }
         }
         else {

--- a/src/ca/SetJsonPathValue.cpp
+++ b/src/ca/SetJsonPathValue.cpp
@@ -54,50 +54,48 @@ HRESULT SetJsonPathValue(__in_z LPCWSTR wzFile, const std::string& sElementPath,
 
             if (createValue) {
                 std::error_code ec;
-                // create_if_missing=true so intermediate objects are created, allowing a nested
+
+                // Preserve the string type when overwriting an existing string value; otherwise
+                // parse the authored value so numbers/booleans/objects become typed JSON.
+                const json* pExisting = NULL;
+                std::error_code ecGet;
+                const json& existing = jsonpointer::get(j, sElementPath, ecGet);
+                if (!ecGet)
+                {
+                    pExisting = &existing;
+                }
+
+                // jsonpointer::add sets the value whether or not the path exists (insert_or_assign),
+                // with create_if_missing=true so intermediate objects are created, allowing a nested
                 // pointer (e.g. /Application/Name) to be built from an empty/partial document.
-                jsonpointer::add_if_absent(j, sElementPath, json(valueUtf8), true, ec);
+                jsonpointer::add(j, sElementPath, MakeJsonValue(valueUtf8, pExisting), true, ec);
 
                 if (ec) {
-                    WcaLog(LOGMSG_STANDARD, "WixJsonFile: Error - JSONPointer add_if_absent failed for path '%s' in file '%ls': %s", 
+                    WcaLog(LOGMSG_STANDARD, "WixJsonFile: Error - JSONPointer add failed for path '%s' in file '%ls': %s",
                            sElementPath.c_str(), wzFile, ec.message().c_str());
                     return E_FAIL;
                 }
-                else {
-                    // Serialize before truncating so a serialization failure cannot leave the file empty.
-                    std::ostringstream serialized;
-                    serialized << pretty_print(j);
 
-                    SetLastError(0);
-                    std::ofstream os(wzFile, std::ios_base::out | std::ios_base::trunc);
-                    if (!os.is_open())
-                    {
-                        WcaLog(LOGMSG_STANDARD, "WixJsonFile: Error - Failed to create output stream for file '%ls'", wzFile);
-                        hr = ReturnLastError("creating the output stream");
-                        return FAILED(hr) ? hr : HRESULT_FROM_WIN32(ERROR_OPEN_FAILED);
-                    }
-
-                    os << serialized.str();
-                    os.close();
-                    if (os.fail())
-                    {
-                        WcaLog(LOGMSG_STANDARD, "WixJsonFile: Error - Failed to write file '%ls'", wzFile);
-                        return HRESULT_FROM_WIN32(ERROR_WRITE_FAULT);
-                    }
-                    WcaLog(LOGMSG_VERBOSE, "WixJsonFile: Successfully created path '%s' in file '%ls'", sElementPath.c_str(), wzFile);
+                hr = WriteJsonOutput(wzFile, j);
+                if (FAILED(hr))
+                {
+                    return hr;
                 }
+                WcaLog(LOGMSG_VERBOSE, "WixJsonFile: Successfully set path '%s' in file '%ls'", sElementPath.c_str(), wzFile);
             }
             else {
 
                 json query = jsonpath::json_query(j, sElementPath);
 
-                WcaLog(LOGMSG_VERBOSE, "WixJsonFile: JSONPath query '%s' found %d element(s) in file '%ls'", 
+                WcaLog(LOGMSG_VERBOSE, "WixJsonFile: JSONPath query '%s' found %d element(s) in file '%ls'",
                        sElementPath.c_str(), query.size(), wzFile);
 
                 if (!query.empty()) {
+                    // Type-preserving update: existing string values stay strings; anything else
+                    // takes the parsed (typed) form of the authored value with string fallback.
                     auto f = [valueUtf8](const std::string& /*path*/, json& value)
                         {
-                            value = valueUtf8;
+                            value = MakeJsonValue(valueUtf8, &value);
                         };
 
                     jsonpath::json_replace(j, sElementPath, f);
@@ -105,29 +103,14 @@ HRESULT SetJsonPathValue(__in_z LPCWSTR wzFile, const std::string& sElementPath,
                     WcaLog(LOGMSG_STANDARD, "WixJsonFile: Successfully updated path '%s' in file '%ls' with value '%s'",
                            sElementPath.c_str(), wzFile, valueUtf8.c_str());
 
-                    // Serialize before truncating so a serialization failure cannot leave the file empty.
-                    std::ostringstream serialized;
-                    serialized << pretty_print(j);
-
-                    SetLastError(0);
-                    std::ofstream os(wzFile, std::ios_base::out | std::ios_base::trunc);
-                    if (!os.is_open())
+                    hr = WriteJsonOutput(wzFile, j);
+                    if (FAILED(hr))
                     {
-                        WcaLog(LOGMSG_STANDARD, "WixJsonFile: Error - Failed to create output stream for file '%ls'", wzFile);
-                        hr = ReturnLastError("creating the output stream");
-                        return FAILED(hr) ? hr : HRESULT_FROM_WIN32(ERROR_OPEN_FAILED);
-                    }
-
-                    os << serialized.str();
-                    os.close();
-                    if (os.fail())
-                    {
-                        WcaLog(LOGMSG_STANDARD, "WixJsonFile: Error - Failed to write file '%ls'", wzFile);
-                        return HRESULT_FROM_WIN32(ERROR_WRITE_FAULT);
+                        return hr;
                     }
                 }
                 else {
-                    WcaLog(LOGMSG_STANDARD, "WixJsonFile: Error - No elements found at path '%s' in file '%ls'. Ensure the path exists or use createJsonPointerValue action to create it.", 
+                    WcaLog(LOGMSG_STANDARD, "WixJsonFile: Error - No elements found at path '%s' in file '%ls'. Ensure the path exists or use createJsonPointerValue action to create it.",
                            sElementPath.c_str(), wzFile);
 
                     return HRESULT_FROM_WIN32(ERROR_OBJECT_NOT_FOUND);

--- a/src/ca/UpdateJsonFile.cpp
+++ b/src/ca/UpdateJsonFile.cpp
@@ -27,79 +27,74 @@ HRESULT UpdateJsonFile(
     }
 
 
+    std::bitset<32> flags(iFlags);
+    WcaLog(LOGMSG_VERBOSE, "WixJsonFile: Processing file '%ls' with flags: %i", wzFile, iFlags);
+
+    // Check if OnlyIfExists flag is set
+    bool onlyIfExists = flags.test(FLAG_ONLYIFEXISTS);
+
+    // OnlyIfExists applies to every write action: skip the operation unless the target path
+    // already exists. createJsonPointerValue uses JSON Pointer syntax; all other actions use JSONPath.
+    bool isWriteAction = flags.test(FLAG_SETVALUE) || flags.test(FLAG_CREATEVALUE) || flags.test(FLAG_REPLACEJSONVALUE) ||
+                         flags.test(FLAG_DELETEVALUE) || flags.test(FLAG_APPENDARRAY) || flags.test(FLAG_INSERTARRAY) ||
+                         flags.test(FLAG_REMOVEARRAYELEMENT) || flags.test(FLAG_DISTINCTVALUES);
+
     // Check if file exists before attempting to parse
     if (!fs::exists(fs::path(wzFile)))
     {
+        // A missing file trivially means the target path does not exist, so OnlyIfExists
+        // turns this into a successful no-op instead of a failed install.
+        if (onlyIfExists && isWriteAction)
+        {
+            WcaLog(LOGMSG_STANDARD, "WixJsonFile: Skipping operation - file does not exist and OnlyIfExists=yes: '%ls'", wzFile);
+            return S_OK;
+        }
+
         WcaLog(LOGMSG_STANDARD, "WixJsonFile: Error - File not found: '%ls'", wzFile);
 
-        // Try to provide additional diagnostic information
+        // Additional diagnostics (verbose so a failing install log is not flooded)
         fs::path filePath(wzFile);
         fs::path parentDir = filePath.parent_path();
         if (!parentDir.empty())
         {
             if (fs::exists(parentDir))
             {
-                WcaLog(LOGMSG_STANDARD, "WixJsonFile: Parent directory exists: '%ls'", parentDir.wstring().c_str());
+                WcaLog(LOGMSG_VERBOSE, "WixJsonFile: Parent directory exists: '%ls'", parentDir.wstring().c_str());
                 // List files in the directory to help diagnose
                 try
                 {
-                    WcaLog(LOGMSG_STANDARD, "WixJsonFile: Files in directory:");
+                    WcaLog(LOGMSG_VERBOSE, "WixJsonFile: Files in directory:");
                     int fileCount = 0;
                     for (const auto& entry : fs::directory_iterator(parentDir))
                     {
                         if (fileCount < 10) // Limit to first 10 files
                         {
-                            WcaLog(LOGMSG_STANDARD, "WixJsonFile:   - %ls", entry.path().filename().wstring().c_str());
+                            WcaLog(LOGMSG_VERBOSE, "WixJsonFile:   - %ls", entry.path().filename().wstring().c_str());
                         }
                         fileCount++;
                     }
                     if (fileCount > 10)
                     {
-                        WcaLog(LOGMSG_STANDARD, "WixJsonFile:   ... and %d more files", fileCount - 10);
+                        WcaLog(LOGMSG_VERBOSE, "WixJsonFile:   ... and %d more files", fileCount - 10);
                     }
                     else if (fileCount == 0)
                     {
-                        WcaLog(LOGMSG_STANDARD, "WixJsonFile:   (directory is empty)");
+                        WcaLog(LOGMSG_VERBOSE, "WixJsonFile:   (directory is empty)");
                     }
                 }
                 catch (...)
                 {
-                    WcaLog(LOGMSG_STANDARD, "WixJsonFile: Could not list directory contents");
+                    WcaLog(LOGMSG_VERBOSE, "WixJsonFile: Could not list directory contents");
                 }
             }
             else
             {
                 WcaLog(LOGMSG_STANDARD, "WixJsonFile: Parent directory does NOT exist: '%ls'", parentDir.wstring().c_str());
-                // Check if grandparent exists
-                fs::path grandparentDir = parentDir.parent_path();
-                if (!grandparentDir.empty() && fs::exists(grandparentDir))
-                {
-                    WcaLog(LOGMSG_STANDARD, "WixJsonFile: Grandparent directory exists: '%ls'", grandparentDir.wstring().c_str());
-                    // List subdirectories to help identify the issue
-                    try
-                    {
-                        WcaLog(LOGMSG_STANDARD, "WixJsonFile: Subdirectories in grandparent:");
-                        for (const auto& entry : fs::directory_iterator(grandparentDir))
-                        {
-                            if (entry.is_directory())
-                            {
-                                WcaLog(LOGMSG_STANDARD, "WixJsonFile:   - %ls", entry.path().filename().wstring().c_str());
-                            }
-                        }
-                    }
-                    catch (...)
-                    {
-                        WcaLog(LOGMSG_STANDARD, "WixJsonFile: Could not list grandparent directory contents");
-                    }
-                }
             }
         }
 
         return HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND);
     }
-
-    std::bitset<32> flags(iFlags);
-    WcaLog(LOGMSG_VERBOSE, "WixJsonFile: Processing file '%ls' with flags: %i", wzFile, iFlags);
 
     std::string elementPath;
     hr = WideToUtf8(wzElementPath, elementPath);
@@ -111,14 +106,6 @@ HRESULT UpdateJsonFile(
 
     WcaLog(LOGMSG_VERBOSE, "Element path: %ls", wzElementPath);
 
-    // Check if OnlyIfExists flag is set
-    bool onlyIfExists = flags.test(FLAG_ONLYIFEXISTS);
-    
-    // OnlyIfExists applies to every write action: skip the operation unless the target path
-    // already exists. createJsonPointerValue uses JSON Pointer syntax; all other actions use JSONPath.
-    bool isWriteAction = flags.test(FLAG_SETVALUE) || flags.test(FLAG_CREATEVALUE) || flags.test(FLAG_REPLACEJSONVALUE) ||
-                         flags.test(FLAG_DELETEVALUE) || flags.test(FLAG_APPENDARRAY) || flags.test(FLAG_INSERTARRAY) ||
-                         flags.test(FLAG_REMOVEARRAYELEMENT) || flags.test(FLAG_DISTINCTVALUES);
     if (onlyIfExists && isWriteAction)
     {
         try

--- a/src/ca/jsonca.vcxproj
+++ b/src/ca/jsonca.vcxproj
@@ -101,6 +101,7 @@
     <ClCompile Include="ExecJsonFile.cpp" />
     <ClCompile Include="ExecJsonFileRollback.cpp" />
     <ClCompile Include="InsertJsonArray.cpp" />
+    <ClCompile Include="JsonWrite.cpp" />
     <ClCompile Include="ReadJsonFileTable.cpp" />
     <ClCompile Include="ReadValueJsonFile.cpp" />
     <ClCompile Include="RemoveJsonArrayElement.cpp" />

--- a/src/ca/jsonca.vcxproj
+++ b/src/ca/jsonca.vcxproj
@@ -11,6 +11,22 @@
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|ARM64">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM64">
+      <Configuration>Release</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{0cee1521-6c12-4826-a551-0dc7ab64ea64}</ProjectGuid>
@@ -30,7 +46,26 @@
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Debug' And ('$(Platform)'=='Win32' Or '$(Platform)'=='ARM64')" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Release' And ('$(Platform)'=='Win32' Or '$(Platform)'=='ARM64')" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <!-- Keep each platform's output in its own $(SolutionDir)<platform> directory so the wixlib can
+       reference all of them side by side (x64 already lands in $(SolutionDir)x64 by default). -->
+  <PropertyGroup Condition="'$(Platform)'=='Win32'">
+    <OutDir>$(SolutionDir)Win32\$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Platform)'=='ARM64'">
+    <OutDir>$(SolutionDir)ARM64\$(Configuration)\</OutDir>
+  </PropertyGroup>
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
@@ -44,6 +79,12 @@
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Debug' And ('$(Platform)'=='Win32' Or '$(Platform)'=='ARM64')">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Release' And ('$(Platform)'=='Win32' Or '$(Platform)'=='ARM64')">
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -92,6 +133,48 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
     </Link>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug' And ('$(Platform)'=='Win32' Or '$(Platform)'=='ARM64')">
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>$(ProjectDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>JSONCONS_NO_DEPRECATED;WIN32;_DEBUG;_WINDOWS;_USRDLL;CUSTOMACTIONTEST_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MinimalRebuild>false</MinimalRebuild>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>msi.lib;version.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <ModuleDefinitionFile>CustomAction.def</ModuleDefinitionFile>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Windows</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Release' And ('$(Platform)'=='Win32' Or '$(Platform)'=='ARM64')">
+    <ClCompile>
+      <Optimization>MaxSpeed</Optimization>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <AdditionalIncludeDirectories>$(ProjectDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>JSONCONS_NO_DEPRECATED;WIN32;NDEBUG;_WINDOWS;_USRDLL;CUSTOMACTIONTEST_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>msi.lib;Version.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <ModuleDefinitionFile>CustomAction.def</ModuleDefinitionFile>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Windows</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+    </Link>
+  </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="AppendJsonArray.cpp" />
     <ClCompile Include="CustomAction.cpp" />
@@ -109,8 +192,7 @@
     <ClCompile Include="SetJsonPathObject.cpp" />
     <ClCompile Include="SetJsonPathValue.cpp" />
     <ClCompile Include="stdafx.cpp">
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
+      <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="UpdateJsonFile.cpp" />
     <ClCompile Include="ValidateJsonSchema.cpp" />

--- a/src/ca/jsonca.vcxproj
+++ b/src/ca/jsonca.vcxproj
@@ -46,16 +46,21 @@
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
+  <!-- For the non-x64 platforms prefer v143 when it is installed, but fall back to the default
+       toolset of the installed Visual Studio: CI runner images do not always carry the v143
+       compatibility toolset for every architecture (e.g. ARM64). -->
   <PropertyGroup Condition="'$(Configuration)'=='Debug' And ('$(Platform)'=='Win32' Or '$(Platform)'=='ARM64')" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset Condition="Exists('$(VCTargetsPath)\Platforms\$(Platform)\PlatformToolsets\v143')">v143</PlatformToolset>
+    <PlatformToolset Condition="'$(PlatformToolset)'==''">$(DefaultPlatformToolset)</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release' And ('$(Platform)'=='Win32' Or '$(Platform)'=='ARM64')" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset Condition="Exists('$(VCTargetsPath)\Platforms\$(Platform)\PlatformToolsets\v143')">v143</PlatformToolset>
+    <PlatformToolset Condition="'$(PlatformToolset)'==''">$(DefaultPlatformToolset)</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <!-- Keep each platform's output in its own $(SolutionDir)<platform> directory so the wixlib can
@@ -147,7 +152,9 @@
       <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>msi.lib;version.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <!-- The WcaUtil/DUtil package props only add their libs for v14x toolsets, so list them
+           explicitly in case the fallback toolset has a different name (duplicates are harmless). -->
+      <AdditionalDependencies>msi.lib;version.lib;..\..\packages\WixToolset.WcaUtil.6.0.1\build\native\v14\$(PlatformTarget)\wcautil.lib;..\..\packages\WixToolset.DUtil.6.0.1\build\native\v14\$(PlatformTarget)\dutil.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>CustomAction.def</ModuleDefinitionFile>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
@@ -167,7 +174,9 @@
       <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>msi.lib;Version.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <!-- The WcaUtil/DUtil package props only add their libs for v14x toolsets, so list them
+           explicitly in case the fallback toolset has a different name (duplicates are harmless). -->
+      <AdditionalDependencies>msi.lib;Version.lib;..\..\packages\WixToolset.WcaUtil.6.0.1\build\native\v14\$(PlatformTarget)\wcautil.lib;..\..\packages\WixToolset.DUtil.6.0.1\build\native\v14\$(PlatformTarget)\dutil.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>CustomAction.def</ModuleDefinitionFile>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>

--- a/src/ca/jsonca.vcxproj.filters
+++ b/src/ca/jsonca.vcxproj.filters
@@ -8,6 +8,7 @@
     <ClCompile Include="ExecJsonFile.cpp" />
     <ClCompile Include="ExecJsonFileRollback.cpp" />
     <ClCompile Include="InsertJsonArray.cpp" />
+    <ClCompile Include="JsonWrite.cpp" />
     <ClCompile Include="ReadJsonFileTable.cpp" />
     <ClCompile Include="ReadValueJsonFile.cpp" />
     <ClCompile Include="RemoveJsonArrayElement.cpp" />

--- a/src/wixext/JsonCompiler.cs
+++ b/src/wixext/JsonCompiler.cs
@@ -22,6 +22,21 @@ namespace Hegsie.Wix.JsonExtension
 		// execution order undefined - the custom action sorts by File, Sequence).
 		private int _nextDefaultSequence = 1;
 
+		/// <summary>
+		/// Resolves the sequence for an element: the authored value wins, then a transaction
+		/// override, then the next default. Future defaults always start above any sequence
+		/// handed out here so unsequenced elements never tie with earlier ones.
+		/// </summary>
+		private int ResolveSequence(int? authoredSequence, int? sequenceOverride = null)
+		{
+			int sequence = authoredSequence ?? sequenceOverride ?? _nextDefaultSequence;
+			if (sequence >= _nextDefaultSequence)
+			{
+				_nextDefaultSequence = sequence + 1;
+			}
+			return sequence;
+		}
+
 		public override XNamespace Namespace => "http://schemas.hegsie.com/wix/JsonExtension";
 
 		/// <summary>
@@ -203,10 +218,7 @@ namespace Hegsie.Wix.JsonExtension
 				file = fileOverride;
 			}
 
-			if (!sequence.HasValue)
-			{
-				sequence = sequenceOverride ?? _nextDefaultSequence++;
-			}
+			sequence = ResolveSequence(sequence, sequenceOverride);
 
 			foreach (var child in node.Elements())
 			{
@@ -762,7 +774,7 @@ namespace Hegsie.Wix.JsonExtension
 				flags = (int)JsonFlags.SetValue | (int)JsonFlags.OnlyIfExists;
 			}
 
-			sequence = sequence ?? _nextDefaultSequence++;
+			sequence = ResolveSequence(sequence);
 
 			var symbol = section.AddSymbol(new JsonFileSymbol(sourceLineNumbers, id)
 			{
@@ -855,7 +867,7 @@ namespace Hegsie.Wix.JsonExtension
 			// Create underlying JsonFile symbol with setValue action
 			int flags = (int)JsonFlags.SetValue;
 
-			sequence = sequence ?? _nextDefaultSequence++;
+			sequence = ResolveSequence(sequence);
 
 			var symbol = section.AddSymbol(new JsonFileSymbol(sourceLineNumbers, id)
 			{
@@ -948,7 +960,7 @@ namespace Hegsie.Wix.JsonExtension
 			// Create underlying JsonFile symbol with setValue action
 			int flags = (int)JsonFlags.SetValue;
 
-			sequence = sequence ?? _nextDefaultSequence++;
+			sequence = ResolveSequence(sequence);
 
 			var symbol = section.AddSymbol(new JsonFileSymbol(sourceLineNumbers, id)
 			{

--- a/src/wixext/JsonCompiler.cs
+++ b/src/wixext/JsonCompiler.cs
@@ -17,6 +17,11 @@ namespace Hegsie.Wix.JsonExtension
 		private static readonly Regex NumericIndexPattern = new Regex(@"^\d+$", RegexOptions.Compiled);
 		private static readonly Regex PropertyReferencePattern = new Regex(@"\[([^\]]+)\]", RegexOptions.Compiled);
 
+		// Elements without an explicit Sequence get an increasing default so operations on the
+		// same file execute in authoring order instead of tying at Sequence=1 (which leaves the
+		// execution order undefined - the custom action sorts by File, Sequence).
+		private int _nextDefaultSequence = 1;
+
 		public override XNamespace Namespace => "http://schemas.hegsie.com/wix/JsonExtension";
 
 		/// <summary>
@@ -83,7 +88,7 @@ namespace Hegsie.Wix.JsonExtension
 		/// <param name="parentDirectory">Identifier of parent component's directory.</param>
 		/// <param name="section"></param>
 		private void ParseJsonFileElement(XElement node, string componentId, string parentDirectory,
-			IntermediateSection section)
+			IntermediateSection section, string fileOverride = null, int? sequenceOverride = null)
 		{
 			var sourceLineNumbers = ParseHelper.GetSourceLineNumbers(node);
 			Identifier id = null;
@@ -95,7 +100,7 @@ namespace Hegsie.Wix.JsonExtension
 			string schemaFile = null;
 			int flags = 0;
 			int action = CompilerConstants.IntegerNotSet;
-			int? sequence = 1;
+			int? sequence = null;
 			int? index = null;
 
 			if (node.Attributes().Any())
@@ -189,6 +194,18 @@ namespace Hegsie.Wix.JsonExtension
 				// default is set value
 				action = (int)JsonAction.SetValue;
 				flags |= (int)JsonFlags.SetValue;
+			}
+
+			// Apply values inherited from a parent JsonTransaction, then fall back to a
+			// deterministic default sequence when none was authored.
+			if (string.IsNullOrEmpty(file) && !string.IsNullOrEmpty(fileOverride))
+			{
+				file = fileOverride;
+			}
+
+			if (!sequence.HasValue)
+			{
+				sequence = sequenceOverride ?? _nextDefaultSequence++;
 			}
 
 			foreach (var child in node.Elements())
@@ -603,7 +620,9 @@ namespace Hegsie.Wix.JsonExtension
 				return;
 			}
 
-			// Parse child JsonFile elements
+			// Parse child JsonFile elements. Defaults from the transaction (File, sequence based
+			// on BaseSequence) are passed as overrides instead of mutating the source XML; the
+			// child's own attributes always win.
 			int sequenceOffset = 0;
 			int childCount = 0;
 			foreach (var child in node.Elements())
@@ -611,22 +630,11 @@ namespace Hegsie.Wix.JsonExtension
 				if (child.Name.Namespace == Namespace && child.Name.LocalName == "JsonFile")
 				{
 					childCount++;
-					
-					// If the child doesn't have File attribute and we have a default, inject it
-					if (!string.IsNullOrEmpty(defaultFile) && child.Attribute("File") == null)
-					{
-						child.SetAttributeValue("File", defaultFile);
-					}
 
-					// If the child doesn't have Sequence attribute, assign one based on baseSequence
-					if (child.Attribute("Sequence") == null && baseSequence.HasValue)
-					{
-						child.SetAttributeValue("Sequence", (baseSequence.Value + sequenceOffset).ToString());
-					}
-					
+					int? childSequence = baseSequence.HasValue ? baseSequence.Value + sequenceOffset : (int?)null;
 					sequenceOffset++;
 
-					ParseJsonFileElement(child, componentId, parentDirectory, section);
+					ParseJsonFileElement(child, componentId, parentDirectory, section, defaultFile, childSequence);
 				}
 				else if (child.Name.Namespace == Namespace)
 				{
@@ -652,7 +660,7 @@ namespace Hegsie.Wix.JsonExtension
 			string file = null;
 			string key = null;
 			string value = null;
-			int? sequence = 1;
+			int? sequence = null;
 			bool createIfMissing = true;
 
 			// Parse attributes
@@ -734,16 +742,27 @@ namespace Hegsie.Wix.JsonExtension
 				Messaging.Write(WarningMessages.InvalidPropertyNameCharacters(sourceLineNumbers, node.Name.ToString(), "Key", key));
 			}
 
-			// Convert dot notation to JSONPath
-			// e.g., "ApplicationSettings.Environment" -> "$.ApplicationSettings.Environment"
-			string elementPath = "$." + key;
-
-			// Create underlying JsonFile symbol
-			int flags = (int)JsonFlags.SetValue; // Default to setValue
-			if (!createIfMissing)
+			// CreateIfMissing=yes (the default) must create the key when it is absent, which the
+			// setValue action cannot do (it fails on missing paths). Map it to the
+			// createJsonPointerValue action, which sets the value and creates intermediate
+			// objects as needed. The dot-notation key converts to a JSON Pointer,
+			// e.g. "ApplicationSettings.Environment" -> "/ApplicationSettings/Environment".
+			// CreateIfMissing=no keeps setValue (JSONPath) with OnlyIfExists so a missing key
+			// is skipped rather than failing the install.
+			string elementPath;
+			int flags;
+			if (createIfMissing)
 			{
-				flags |= (int)JsonFlags.OnlyIfExists;
+				elementPath = "/" + key.Replace(".", "/");
+				flags = (int)JsonFlags.CreateJsonPointerValue;
 			}
+			else
+			{
+				elementPath = "$." + key;
+				flags = (int)JsonFlags.SetValue | (int)JsonFlags.OnlyIfExists;
+			}
+
+			sequence = sequence ?? _nextDefaultSequence++;
 
 			var symbol = section.AddSymbol(new JsonFileSymbol(sourceLineNumbers, id)
 			{
@@ -770,7 +789,7 @@ namespace Hegsie.Wix.JsonExtension
 			string file = null;
 			string name = null;
 			string value = null;
-			int? sequence = 1;
+			int? sequence = null;
 
 			// Parse attributes
 			foreach (var attribute in node.Attributes())
@@ -836,6 +855,8 @@ namespace Hegsie.Wix.JsonExtension
 			// Create underlying JsonFile symbol with setValue action
 			int flags = (int)JsonFlags.SetValue;
 
+			sequence = sequence ?? _nextDefaultSequence++;
+
 			var symbol = section.AddSymbol(new JsonFileSymbol(sourceLineNumbers, id)
 			{
 				File = file,
@@ -861,7 +882,7 @@ namespace Hegsie.Wix.JsonExtension
 			string file = null;
 			string category = "Default";
 			string level = null;
-			int? sequence = 1;
+			int? sequence = null;
 
 			// Parse attributes
 			foreach (var attribute in node.Attributes())
@@ -926,6 +947,8 @@ namespace Hegsie.Wix.JsonExtension
 
 			// Create underlying JsonFile symbol with setValue action
 			int flags = (int)JsonFlags.SetValue;
+
+			sequence = sequence ?? _nextDefaultSequence++;
 
 			var symbol = section.AddSymbol(new JsonFileSymbol(sourceLineNumbers, id)
 			{

--- a/src/wixext/JsonCompiler.cs
+++ b/src/wixext/JsonCompiler.cs
@@ -254,7 +254,7 @@ namespace Hegsie.Wix.JsonExtension
 
 			ParseHelper.CreateCustomActionReference(sourceLineNumbers, section,
 				action == (int)JsonAction.ReadValue ? "WixPropertyJsonFile" : "WixSchedJsonFile", Context.Platform,
-				CustomActionPlatforms.X64);
+				CustomActionPlatforms.X86 | CustomActionPlatforms.X64 | CustomActionPlatforms.ARM64);
 		}
 
 		private int ValidateAction(XElement node, SourceLineNumber sourceLineNumbers, XAttribute attribute,
@@ -775,7 +775,7 @@ namespace Hegsie.Wix.JsonExtension
 			});
 
 			ParseHelper.CreateCustomActionReference(sourceLineNumbers, section, "WixSchedJsonFile", Context.Platform,
-				CustomActionPlatforms.X64);
+				CustomActionPlatforms.X86 | CustomActionPlatforms.X64 | CustomActionPlatforms.ARM64);
 		}
 
 		/// <summary>
@@ -868,7 +868,7 @@ namespace Hegsie.Wix.JsonExtension
 			});
 
 			ParseHelper.CreateCustomActionReference(sourceLineNumbers, section, "WixSchedJsonFile", Context.Platform,
-				CustomActionPlatforms.X64);
+				CustomActionPlatforms.X86 | CustomActionPlatforms.X64 | CustomActionPlatforms.ARM64);
 		}
 
 		/// <summary>
@@ -961,7 +961,7 @@ namespace Hegsie.Wix.JsonExtension
 			});
 
 			ParseHelper.CreateCustomActionReference(sourceLineNumbers, section, "WixSchedJsonFile", Context.Platform,
-				CustomActionPlatforms.X64);
+				CustomActionPlatforms.X86 | CustomActionPlatforms.X64 | CustomActionPlatforms.ARM64);
 		}
 	}
 

--- a/src/wixext/json.xsd
+++ b/src/wixext/json.xsd
@@ -59,7 +59,8 @@
       <xs:enumeration value="createJsonPointerValue">
         <xs:annotation>
           <xs:documentation>
-            Creates a new value using JSONPointer syntax (useful for creating nested paths that don't exist).
+            Sets a value using JSONPointer syntax, creating the path (including intermediate objects)
+            if it doesn't exist. Existing values at the path are overwritten.
             ElementPath should use JSONPointer format (e.g., /path/to/element).
           </xs:documentation>
         </xs:annotation>
@@ -191,10 +192,12 @@
           </xs:documentation>
         </xs:annotation>
       </xs:attribute>
-      <xs:attribute name="Sequence" type="wxs:Integer" default="1">
+      <xs:attribute name="Sequence" type="wxs:Integer">
         <xs:annotation>
           <xs:documentation>
-            Order in which modifications are applied (default: 1). Lower numbers execute first.
+            Order in which modifications are applied. Lower numbers execute first.
+            When omitted, elements are assigned increasing sequence numbers in authoring order,
+            so operations on the same file execute deterministically in the order they appear.
             Use this to ensure JSON changes happen in the correct order or before services start.
             All JSON modifications run after InstallFiles and before StartServices in the standard InstallExecuteSequence.
           </xs:documentation>
@@ -221,8 +224,9 @@
         <xs:annotation>
           <xs:documentation>
             When set to 'yes', the action is only performed if the ElementPath already exists in the JSON file.
+            If the path (or the JSON file itself) does not exist, the operation is skipped without failing the install.
             This is useful for conditional updates that should only modify existing values without creating new ones.
-            Applies to setValue, createJsonPointerValue, and replaceJsonValue actions. Default is 'no'.
+            Applies to all write actions. Default is 'no'.
           </xs:documentation>
         </xs:annotation>
       </xs:attribute>
@@ -359,8 +363,10 @@
       <xs:attribute name="CreateIfMissing" type="wxs:YesNoTypeUnion" default="yes">
         <xs:annotation>
           <xs:documentation>
-            When set to 'yes' (default), creates the nested path if it doesn't exist.
-            When set to 'no', only updates if the path already exists (equivalent to OnlyIfExists="yes").
+            When set to 'yes' (default), the setting is written with the createJsonPointerValue action,
+            creating the key (including intermediate objects) when it doesn't exist and overwriting it when it does.
+            When set to 'no', only updates if the path already exists (equivalent to OnlyIfExists="yes");
+            missing keys are skipped without failing the install.
           </xs:documentation>
         </xs:annotation>
       </xs:attribute>

--- a/src/wixlib/JsonExtension.wixproj
+++ b/src/wixlib/JsonExtension.wixproj
@@ -12,6 +12,15 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
     <LibAdditionalOptions>-b $(SolutionDir)src\ca\bin\$(Configuration)</LibAdditionalOptions>
   </PropertyGroup>
+  <!-- Compile the x86/ARM64 custom action fragments only when those DLLs have been built, so a
+       plain x64 development build still works. CI builds jsonca for Win32 and ARM64 before the
+       solution, which makes official wixlibs carry all three platforms. -->
+  <PropertyGroup Condition="Exists('$(SolutionDir)Win32\$(Configuration)\jsonca.dll')">
+    <DefineConstants>$(DefineConstants);IncludeX86</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="Exists('$(SolutionDir)ARM64\$(Configuration)\jsonca.dll')">
+    <DefineConstants>$(DefineConstants);IncludeArm64</DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ca\jsonca.vcxproj" Platforms="x64" />
   </ItemGroup>

--- a/src/wixlib/Library.wxs
+++ b/src/wixlib/Library.wxs
@@ -18,6 +18,11 @@
       <Custom Action="WixPropertyJsonFile_X64" After="CostFinalize" />
       <Custom Action="WixSchedJsonFile_X64" After="InstallFiles" />
     </InstallExecuteSequence>
+
+    <!-- Message shown when the custom actions raise error 25530 (see msierrJsonFileFailedRead). -->
+    <UI>
+      <Error Id="25530" Message="Failed to read the WixJsonFile table. Check the installation log for details." />
+    </UI>
   </Fragment>
 
   <Fragment Id="JsonFileCustomActions">

--- a/src/wixlib/Library.wxs
+++ b/src/wixlib/Library.wxs
@@ -1,31 +1,85 @@
-﻿<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <!--
+    One fragment per platform: the compiler extension references WixSchedJsonFile_<platform>
+    (or WixPropertyJsonFile_<platform> for readValue), which pulls in exactly one of these
+    fragments and, through the BinaryRef, the matching custom action DLL.
+
+    WixSchedJsonFile is sequenced in the InstallExecuteSequence and therefore runs on install,
+    uninstall, and repair. The custom action self-gates on component install state
+    (WcaIsInstalling), so it is a no-op on uninstall. Consequently JSON modifications are applied
+    on install/repair and are NOT reverted on uninstall; the rollback action only restores files
+    that were captured before a failed install. Install/uninstall timing control is tracked as a
+    future enhancement (see issue #39).
+  -->
   <Fragment Id="JsonFile">
     <CustomAction Id="WixPropertyJsonFile_X64" DllEntry="ReadValueJsonFile" Execute="immediate" Return="check" BinaryRef="jsonca.dll" Impersonate="no" />
-    
+
     <CustomAction Id="WixSchedJsonFile_X64" DllEntry="SchedJsonFile" Execute="immediate" Return="check" BinaryRef="jsonca.dll" Impersonate="no" />
     <CustomAction Id="WixExecJsonFile_X64" DllEntry="ExecJsonFile" Execute="deferred" Impersonate="no" Return="check" HideTarget="yes" SuppressModularization="yes" BinaryRef="jsonca.dll" />
     <CustomAction Id="WixExecJsonFileRollback_X64" DllEntry="ExecJsonFileRollback" Execute="rollback" Impersonate="no" Return="check" HideTarget="yes" SuppressModularization="yes" BinaryRef="jsonca.dll" />
-    
-    <!--
-      WixSchedJsonFile is sequenced in the InstallExecuteSequence and therefore runs on install,
-      uninstall, and repair. The custom action self-gates on component install state
-      (WcaIsInstalling), so it is a no-op on uninstall. Consequently JSON modifications are applied
-      on install/repair and are NOT reverted on uninstall; the rollback action only restores files
-      that were captured before a failed install. Install/uninstall timing control is tracked as a
-      future enhancement (see issue #39).
-    -->
+
     <InstallExecuteSequence>
       <Custom Action="WixPropertyJsonFile_X64" After="CostFinalize" />
       <Custom Action="WixSchedJsonFile_X64" After="InstallFiles" />
     </InstallExecuteSequence>
 
-    <!-- Message shown when the custom actions raise error 25530 (see msierrJsonFileFailedRead). -->
-    <UI>
-      <Error Id="25530" Message="Failed to read the WixJsonFile table. Check the installation log for details." />
-    </UI>
+    <UIRef Id="JsonFileErrorsUI" />
   </Fragment>
 
   <Fragment Id="JsonFileCustomActions">
     <Binary Id="jsonca.dll" SourceFile="$(SolutionDir)x64\$(Configuration)\jsonca.dll" />
   </Fragment>
+
+  <!-- Message shown when the custom actions raise error 25530 (see msierrJsonFileFailedRead).
+       Shared by every platform fragment via UIRef so the symbol exists exactly once. -->
+  <Fragment Id="JsonFileErrors">
+    <UI Id="JsonFileErrorsUI">
+      <Error Id="25530" Message="Failed to read the WixJsonFile table. Check the installation log for details." />
+    </UI>
+  </Fragment>
+
+  <!-- The x86 and ARM64 fragments are only compiled in when the corresponding DLL has been
+       built (the wixproj defines IncludeX86/IncludeArm64 based on the build output), so a
+       plain x64 development build still links. CI builds all three platforms. -->
+  <?ifdef IncludeX86 ?>
+  <Fragment Id="JsonFileX86">
+    <CustomAction Id="WixPropertyJsonFile_X86" DllEntry="ReadValueJsonFile" Execute="immediate" Return="check" BinaryRef="jsonca_x86.dll" Impersonate="no" />
+
+    <CustomAction Id="WixSchedJsonFile_X86" DllEntry="SchedJsonFile" Execute="immediate" Return="check" BinaryRef="jsonca_x86.dll" Impersonate="no" />
+    <CustomAction Id="WixExecJsonFile_X86" DllEntry="ExecJsonFile" Execute="deferred" Impersonate="no" Return="check" HideTarget="yes" SuppressModularization="yes" BinaryRef="jsonca_x86.dll" />
+    <CustomAction Id="WixExecJsonFileRollback_X86" DllEntry="ExecJsonFileRollback" Execute="rollback" Impersonate="no" Return="check" HideTarget="yes" SuppressModularization="yes" BinaryRef="jsonca_x86.dll" />
+
+    <InstallExecuteSequence>
+      <Custom Action="WixPropertyJsonFile_X86" After="CostFinalize" />
+      <Custom Action="WixSchedJsonFile_X86" After="InstallFiles" />
+    </InstallExecuteSequence>
+
+    <UIRef Id="JsonFileErrorsUI" />
+  </Fragment>
+
+  <Fragment Id="JsonFileCustomActionsX86">
+    <Binary Id="jsonca_x86.dll" SourceFile="$(SolutionDir)Win32\$(Configuration)\jsonca.dll" />
+  </Fragment>
+  <?endif?>
+
+  <?ifdef IncludeArm64 ?>
+  <Fragment Id="JsonFileArm64">
+    <CustomAction Id="WixPropertyJsonFile_A64" DllEntry="ReadValueJsonFile" Execute="immediate" Return="check" BinaryRef="jsonca_a64.dll" Impersonate="no" />
+
+    <CustomAction Id="WixSchedJsonFile_A64" DllEntry="SchedJsonFile" Execute="immediate" Return="check" BinaryRef="jsonca_a64.dll" Impersonate="no" />
+    <CustomAction Id="WixExecJsonFile_A64" DllEntry="ExecJsonFile" Execute="deferred" Impersonate="no" Return="check" HideTarget="yes" SuppressModularization="yes" BinaryRef="jsonca_a64.dll" />
+    <CustomAction Id="WixExecJsonFileRollback_A64" DllEntry="ExecJsonFileRollback" Execute="rollback" Impersonate="no" Return="check" HideTarget="yes" SuppressModularization="yes" BinaryRef="jsonca_a64.dll" />
+
+    <InstallExecuteSequence>
+      <Custom Action="WixPropertyJsonFile_A64" After="CostFinalize" />
+      <Custom Action="WixSchedJsonFile_A64" After="InstallFiles" />
+    </InstallExecuteSequence>
+
+    <UIRef Id="JsonFileErrorsUI" />
+  </Fragment>
+
+  <Fragment Id="JsonFileCustomActionsArm64">
+    <Binary Id="jsonca_a64.dll" SourceFile="$(SolutionDir)ARM64\$(Configuration)\jsonca.dll" />
+  </Fragment>
+  <?endif?>
 </Wix>

--- a/test/jsonca.tests/jsonca.tests.vcxproj
+++ b/test/jsonca.tests/jsonca.tests.vcxproj
@@ -72,6 +72,7 @@
     <ClCompile Include="..\..\src\ca\DistinctJsonArray.cpp" />
     <ClCompile Include="..\..\src\ca\Errors.cpp" />
     <ClCompile Include="..\..\src\ca\InsertJsonArray.cpp" />
+    <ClCompile Include="..\..\src\ca\JsonWrite.cpp" />
     <ClCompile Include="..\..\src\ca\RemoveJsonArrayElement.cpp" />
     <ClCompile Include="..\..\src\ca\SetJsonPathObject.cpp" />
     <ClCompile Include="..\..\src\ca\SetJsonPathValue.cpp" />

--- a/test/jsonca.tests/tests.cpp
+++ b/test/jsonca.tests/tests.cpp
@@ -149,6 +149,91 @@ static void Test_OnlyIfExists_AppliesWhenPresent()
     RemoveFile(path);
 }
 
+static void Test_SetValue_PreservesStringType()
+{
+    // Replacing an existing string with something that parses as JSON must stay a string.
+    auto path = WriteTempJson(R"({"version":"1.0"})");
+    CHECK_HR(UpdateJsonFile(path.c_str(), L"$.version", L"2.5", FlagFor(FLAG_SETVALUE), -1, L""));
+    auto j = ReadJson(path);
+    CHECK(j["version"].is_string());
+    CHECK(j["version"].as<std::string>() == "2.5");
+    RemoveFile(path);
+}
+
+static void Test_SetValue_WritesTypedValueForNonStrings()
+{
+    // Replacing a number/boolean takes the parsed (typed) form of the authored value.
+    auto path = WriteTempJson(R"({"port":8080,"enabled":false})");
+    CHECK_HR(UpdateJsonFile(path.c_str(), L"$.port", L"9090", FlagFor(FLAG_SETVALUE), -1, L""));
+    CHECK_HR(UpdateJsonFile(path.c_str(), L"$.enabled", L"true", FlagFor(FLAG_SETVALUE), -1, L""));
+    auto j = ReadJson(path);
+    CHECK(j["port"].is_number());
+    CHECK(j["port"].as<int>() == 9090);
+    CHECK(j["enabled"].is_bool());
+    CHECK(j["enabled"].as<bool>() == true);
+    RemoveFile(path);
+}
+
+static void Test_CreatePointer_UpdatesExistingValue()
+{
+    // createJsonPointerValue is set-or-create: an existing value is replaced, not left as-is.
+    auto path = WriteTempJson(R"({"a":{"b":"old"}})");
+    CHECK_HR(UpdateJsonFile(path.c_str(), L"/a/b", L"new", FlagFor(FLAG_CREATEVALUE), -1, L""));
+    auto j = ReadJson(path);
+    CHECK(j["a"]["b"].as<std::string>() == "new");
+    RemoveFile(path);
+}
+
+static void Test_CreatePointer_TypedValueForNewPath()
+{
+    // A newly created value has no existing type to preserve, so JSON-parseable text is typed.
+    auto path = WriteTempJson(R"({})");
+    CHECK_HR(UpdateJsonFile(path.c_str(), L"/timeout", L"30", FlagFor(FLAG_CREATEVALUE), -1, L""));
+    auto j = ReadJson(path);
+    CHECK(j["timeout"].is_number());
+    CHECK(j["timeout"].as<int>() == 30);
+    RemoveFile(path);
+}
+
+static void Test_OnlyIfExists_SkipsMissingFile()
+{
+    // A missing file with OnlyIfExists is a successful no-op, not a failed install.
+    fs::path missing = fs::temp_directory_path() / L"jsonca_test_missing_file.json";
+    RemoveFile(missing.wstring());
+    int flags = FlagFor(FLAG_SETVALUE) | FlagFor(FLAG_ONLYIFEXISTS);
+    CHECK_HR(UpdateJsonFile(missing.wstring().c_str(), L"$.config.value", L"x", flags, -1, L""));
+    CHECK(!fs::exists(missing));
+}
+
+static void Test_RemoveArrayElement_ByValue()
+{
+    auto path = WriteTempJson(R"({"items":["a","b","a"]})");
+    CHECK_HR(UpdateJsonFile(path.c_str(), L"$.items", L"a", FlagFor(FLAG_REMOVEARRAYELEMENT), -1, L""));
+    auto j = ReadJson(path);
+    CHECK(j["items"].size() == 1);
+    CHECK(j["items"][0].as<std::string>() == "b");
+    RemoveFile(path);
+}
+
+static void Test_DistinctArray_RemovesDuplicates()
+{
+    auto path = WriteTempJson(R"({"items":[1,2,1,3,2]})");
+    CHECK_HR(UpdateJsonFile(path.c_str(), L"$.items", L"", FlagFor(FLAG_DISTINCTVALUES), -1, L""));
+    auto j = ReadJson(path);
+    CHECK(j["items"].size() == 3);
+    RemoveFile(path);
+}
+
+static void Test_Write_LeavesNoTempFile()
+{
+    auto path = WriteTempJson(R"({"config":{"value":"old"}})");
+    CHECK_HR(UpdateJsonFile(path.c_str(), L"$.config.value", L"new", FlagFor(FLAG_SETVALUE), -1, L""));
+    fs::path tempPath(path);
+    tempPath += L".wixjson.tmp";
+    CHECK(!fs::exists(tempPath));
+    RemoveFile(path);
+}
+
 static void Test_Schema_ValidPasses_InvalidFails()
 {
     auto schemaPath = WriteTempJson(
@@ -231,6 +316,14 @@ int main(int argc, char** argv)
     RunTest("InsertArray_AtIndex", Test_InsertArray_AtIndex);
     RunTest("OnlyIfExists_SkipsMissingPath", Test_OnlyIfExists_SkipsMissingPath);
     RunTest("OnlyIfExists_AppliesWhenPresent", Test_OnlyIfExists_AppliesWhenPresent);
+    RunTest("SetValue_PreservesStringType", Test_SetValue_PreservesStringType);
+    RunTest("SetValue_WritesTypedValueForNonStrings", Test_SetValue_WritesTypedValueForNonStrings);
+    RunTest("CreatePointer_UpdatesExistingValue", Test_CreatePointer_UpdatesExistingValue);
+    RunTest("CreatePointer_TypedValueForNewPath", Test_CreatePointer_TypedValueForNewPath);
+    RunTest("OnlyIfExists_SkipsMissingFile", Test_OnlyIfExists_SkipsMissingFile);
+    RunTest("RemoveArrayElement_ByValue", Test_RemoveArrayElement_ByValue);
+    RunTest("DistinctArray_RemovesDuplicates", Test_DistinctArray_RemovesDuplicates);
+    RunTest("Write_LeavesNoTempFile", Test_Write_LeavesNoTempFile);
     RunTest("Schema_ValidPasses_InvalidFails", Test_Schema_ValidPasses_InvalidFails);
 
     std::string out = (argc > 1) ? argv[1] : "cpp-tests.xml";


### PR DESCRIPTION
Fixes for the issues found reviewing the implementation:

High severity:
- AppSettings CreateIfMissing=yes (the default) now actually creates missing
  keys: it maps to the createJsonPointerValue action with a JSON Pointer path
  instead of plain setValue, which failed the install on missing paths.
  CreateIfMissing=no keeps setValue+OnlyIfExists (skip when missing).
- readValue now applies DefaultValue when the JSON file does not exist,
  consistent with parse failures and missing paths.

Medium severity:
- All write paths now go through a shared WriteJsonOutput helper that
  serializes to a temp file and swaps it in with ReplaceFileW/MoveFileExW,
  so a serialization or write failure (or crash mid-write) can never
  truncate or corrupt the target file. This also adds the previously
  missing write-failure checks to removeArrayElement and distinctValues.
- OnlyIfExists=yes now skips (returns success) when the JSON file itself is
  missing instead of failing the install, matching the documented semantics.
- Rollback restores with CREATE_ALWAYS instead of TRUNCATE_EXISTING so the
  captured contents come back even if the file was deleted in between.
- Consistent value typing: setValue/createJsonPointerValue preserve the
  string type when replacing an existing string, and otherwise parse the
  authored value so numbers/booleans/objects become typed JSON (matching
  the array actions). createJsonPointerValue is now set-or-create
  (jsonpointer::add) instead of silently ignoring existing values.

Low severity:
- Index null handling: WcaGetRecordInteger returns S_FALSE with
  MSI_NULL_INTEGER for null columns, which the FAILED() check missed.
- GetLastErrorAsString no longer constructs a std::string from a null
  buffer when FormatMessage fails.
- JsonTransaction no longer mutates the source XML; defaults are passed as
  overrides to the JsonFile parser.
- Elements without an explicit Sequence get increasing defaults in
  authoring order instead of all tying at 1 (nondeterministic order).
- Authored Error table entry for message 25530 so MessageExitOnFailure
  shows meaningful text.
- Removed dead E_NOMOREITEMS checks, duplicate scheduling log, and
  downgraded missing-file directory-listing diagnostics to verbose.

Tests: new C++ unit tests cover type preservation, typed writes,
set-or-create pointer semantics, OnlyIfExists on a missing file,
removeArrayElement/distinctValues round-trips, and temp-file cleanup.
Docs: README and json.xsd updated for the changed behaviors.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Tq7aAv4ZKq8Y2e99J4BtQD